### PR TITLE
Updated to use latest NGINX and NJS

### DIFF
--- a/Dockerfile.oss
+++ b/Dockerfile.oss
@@ -1,48 +1,12 @@
-FROM nginx:1.19.5
+FROM nginx:1.19.7
 
-ENV NGINX_VERSION "1.19.5"
-ENV HEADERS_MORE_VERSION "v0.33"
+ENV NGINX_VERSION "1.19.7"
 
 # We modify the nginx base image by:
-# 1. Installing the headers-more module
-# 2. Adding configuration files needed for proxying private S3 buckets
-# 3. Adding a directory for proxied objects to be stored
-# 4. Replacing the entrypoint script with a modified version that explicitly
+# 1. Adding configuration files needed for proxying private S3 buckets
+# 2. Adding a directory for proxied objects to be stored
+# 3. Replacing the entrypoint script with a modified version that explicitly
 #    sets resolvers.
-
-RUN set -eux \
-    export DEBIAN_FRONTEND=noninteractive; \
-    apt-get update -qq; \
-    apt-get install -y -qq build-essential libpcre3-dev git; \
-    curl -o /tmp/nginx.tar.gz --retry 6 -Ls "http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz"; \
-    mkdir /tmp/nginx /tmp/headers-more; \
-    tar -C /tmp/nginx --strip-components 1 -xzf /tmp/nginx.tar.gz; \
-    curl -o /tmp/headers-more.tar.gz --retry 6 -Ls "https://github.com/openresty/headers-more-nginx-module/archive/${HEADERS_MORE_VERSION}.tar.gz"; \
-    tar -C "/tmp/headers-more" --strip-components 1 -xzf /tmp/headers-more.tar.gz; \
-    cd /tmp/nginx; \
-    ./configure --add-dynamic-module=/tmp/headers-more \
-                --without-http_gzip_module \
-                --prefix=/etc/nginx \
-                --sbin-path=/usr/sbin/nginx \
-                --modules-path=/usr/lib/nginx/modules \
-                --conf-path=/etc/nginx/nginx.conf \
-                --error-log-path=/var/log/nginx/error.log \
-                --http-log-path=/var/log/nginx/access.log \
-                --pid-path=/var/run/nginx.pid \
-                --lock-path=/var/run/nginx.lock \
-                --http-client-body-temp-path=/var/cache/nginx/client_temp \
-                --http-proxy-temp-path=/var/cache/nginx/proxy_temp \
-                --http-fastcgi-temp-path=/var/cache/nginx/fastcgi_temp \
-                --http-uwsgi-temp-path=/var/cache/nginx/uwsgi_temp \
-                --http-scgi-temp-path=/var/cache/nginx/scgi_temp \
-                --user=nginx --group=nginx --with-compat --with-file-aio \
-                --with-threads \
-                --with-cc-opt="-g -O2 -fdebug-prefix-map=/data/builder/debuild/nginx-${NGINX_VERSION}/debian/debuild-base/nginx-${NGINX_VERSION}=. -fstack-protector-strong -Wformat -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fPIC" \
-                --with-ld-opt='-Wl,-z,relro -Wl,-z,now -Wl,--as-needed -pie'; \
-    make -j $(nproc) modules; \
-    cp /tmp/nginx/objs/ngx_http_headers_more_filter_module.so /usr/lib/nginx/modules; \
-    apt-get purge -y --auto-remove build-essential libpcre3-dev git; \
-    rm -rf /var/lib/apt/lists/* /var/tmp/* /tmp/*
 
 COPY common/etc /etc
 COPY common/docker-entrypoint.sh /docker-entrypoint.sh

--- a/Dockerfile.plus
+++ b/Dockerfile.plus
@@ -5,8 +5,7 @@ ARG NGINX_GPGKEY
 ENV NGINX_VERSION        23
 ENV PKG_RELEASE          1~buster
 
-ENV NJS_VERSION          0.5.0
-ENV HEADERS_MORE_VERSION 0.33
+ENV NJS_VERSION          0.5.1
 
 COPY plus/etc/ssl /etc/ssl
 COPY plus/usr /usr
@@ -29,7 +28,6 @@ RUN set -eux \
     apt-get -qq update; \
     apt-get -qq install --no-install-recommends --no-install-suggests -y \
         nginx-plus=${NGINX_VERSION}-${PKG_RELEASE} \
-        nginx-plus-module-headers-more=${NGINX_VERSION}+${HEADERS_MORE_VERSION}-${PKG_RELEASE} \
         nginx-plus-module-njs=${NGINX_VERSION}+${NJS_VERSION}-${PKG_RELEASE} \
         gettext-base; \
     apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \

--- a/common/etc/nginx/include/s3gateway.js
+++ b/common/etc/nginx/include/s3gateway.js
@@ -49,6 +49,20 @@ var emptyPayloadHash = 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b
 var signedHeaders = 'host;x-amz-content-sha256;x-amz-date';
 
 /**
+ * Strips all x-amz- headers from the output HTTP headers.
+ * @param r HTTP request
+ */
+function filterOutAmzHeaders(r) {
+    if ('headersOut' in r) {
+        for (var key in r.headersOut) {
+            if (key.toLowerCase().indexOf("x-amz-", 0) >= 0) {
+                delete r.headersOut[key];
+            }
+        }
+    }
+}
+
+/**
  * Outputs the timestamp used to sign the request, so that it can be added to
  * the 'Date' header and sent by NGINX.
  *
@@ -446,6 +460,7 @@ export default {
     s3date,
     s3auth,
     redirectToS3,
+    filterOutAmzHeaders,
 
     // These functions do not need to be exposed, but they are exposed so that
     // unit tests can run against them.

--- a/common/etc/nginx/nginx.conf
+++ b/common/etc/nginx/nginx.conf
@@ -6,7 +6,6 @@ pid        /var/run/nginx.pid;
 
 # NJS module used for implementing S3 authentication
 load_module modules/ngx_http_js_module.so;
-load_module modules/ngx_http_headers_more_filter_module.so;
 
 # Preserve S3 environment variables for worker threads
 env S3_ACCESS_KEY_ID;

--- a/common/etc/nginx/templates/default.conf.template
+++ b/common/etc/nginx/templates/default.conf.template
@@ -93,7 +93,7 @@ server {
         # We strip off all of the AWS specific headers from the server so that
         # there is nothing identifying the object as having originated in an
         # object store.
-        more_clear_headers 'x-amz-*';
+        js_header_filter s3gateway.filterOutAmzHeaders;
 
         # Catch all errors from S3 and sanitize them so that the user can't
         # gain intelligence about the S3 bucket being proxied.

--- a/plus/usr/local/bin/add_nginx_plus_repo.sh
+++ b/plus/usr/local/bin/add_nginx_plus_repo.sh
@@ -34,6 +34,8 @@ fi
 
 apt-get -qq install --no-install-recommends --no-install-suggests -y apt-transport-https gnupg1 ca-certificates
 
+version_codename="$(grep '^VERSION_CODENAME=' /etc/os-release | awk -v FS='=' '{print $2}')"
+
 found=''
 for server in \
     ha.pool.sks-keyservers.net \
@@ -50,4 +52,4 @@ done
     echo "Acquire::https::plus-pkgs.nginx.com::Verify-Host \"true\";" >> /etc/apt/apt.conf.d/90nginx
     echo "Acquire::https::plus-pkgs.nginx.com::SslCert     \"/etc/ssl/nginx/nginx-repo.crt\";" >> /etc/apt/apt.conf.d/90nginx
     echo "Acquire::https::plus-pkgs.nginx.com::SslKey      \"/etc/ssl/nginx/nginx-repo.key\";" >> /etc/apt/apt.conf.d/90nginx
-    echo "deb https://plus-pkgs.nginx.com/debian buster nginx-plus" >> /etc/apt/sources.list.d/nginx-plus.list
+    echo "deb https://plus-pkgs.nginx.com/debian ${version_codename} nginx-plus" >> /etc/apt/sources.list.d/nginx-plus.list

--- a/test/docker-compose.yaml
+++ b/test/docker-compose.yaml
@@ -23,7 +23,7 @@ services:
       S3_DEBUG: "true"
       AWS_SIGS_VERSION:
   minio:
-    image: "minio/minio:RELEASE.2020-09-17T04-49-20Z"
+    image: "minio/minio:RELEASE.2021-02-19T04-38-02Z"
     ports:
       - "9090:9000/tcp"
     restart: "no"

--- a/test/unit/s3gateway_test.js
+++ b/test/unit/s3gateway_test.js
@@ -225,6 +225,32 @@ function testSignatureV4Cache() {
     _runSignatureV4(r);
 }
 
+function testFilterOutAmzHeaders() {
+    var r = {
+        "headersOut" : {
+            "Accept-Ranges": "bytes",
+            "Content-Length": 42,
+            "Content-Security-Policy": "block-all-mixed-content",
+            "Content-Type": "text/plain",
+            "X-Amz-Bucket-Region": "us-east-1",
+            "X-Amz-Request-Id": "166539E18A46500A",
+            "X-Xss-Protection": "1; mode=block"
+        }
+    }
+
+    r.log = function(msg) {
+        console.log(msg);
+    }
+
+    s3gateway.filterOutAmzHeaders(r);
+
+    for (var key in r.headersOut) {
+        if (key.toLowerCase().indexOf("x-amz", 0) >= 0) {
+            throw "x-amz header not stripped from headers correctly";
+        }
+    }
+}
+
 function test() {
     testPad();
     testEightDigitDate();
@@ -234,6 +260,7 @@ function test() {
     testBuildSigningKeyHashWithTestSuiteInputs();
     testSignatureV4();
     testSignatureV4Cache();
+    testFilterOutAmzHeaders();
 }
 
 test();


### PR DESCRIPTION
This change upgrades NGINX to 1.19.7 and NJS to 0.5.1.
In this new version of NJS, it provides a filter function
that allows for headersOut to be modified thereby removing
the need for the headers_more module to strip off x-amz
headers.