### PR TITLE
Fix #25

### DIFF
--- a/test/data/bucket-1/b/クズ箱/ゴミ.txt
+++ b/test/data/bucket-1/b/クズ箱/ゴミ.txt
@@ -1,0 +1,1 @@
+What is the sound of two hands clapping?

--- a/test/data/bucket-1/системы/system.txt
+++ b/test/data/bucket-1/системы/system.txt
@@ -1,0 +1,1 @@
+The rewrite will not fix it.

--- a/test/integration/test_api.sh
+++ b/test/integration/test_api.sh
@@ -117,6 +117,8 @@ assertHttpRequestEquals "HEAD" "b/ブツブツ.txt" "200"
 # Weird filenames
 assertHttpRequestEquals "HEAD" "b/c/=" "200"
 assertHttpRequestEquals "HEAD" "b/c/@" "200"
+assertHttpRequestEquals "HEAD" "b/クズ箱/ゴミ.txt" "200"
+assertHttpRequestEquals "HEAD" "системы/system.txt" "200"
 
 # Expected 400s
 assertHttpRequestEquals "HEAD" "request with unencoded spaces" "400"
@@ -149,6 +151,8 @@ assertHttpRequestEquals "GET" "b/c/d.txt" "data/bucket-1/b/c/d.txt"
 assertHttpRequestEquals "GET" "b/c/=" "data/bucket-1/b/c/="
 assertHttpRequestEquals "GET" "b/e.txt" "data/bucket-1/b/e.txt"
 assertHttpRequestEquals "GET" "b/ブツブツ.txt" "data/bucket-1/b/ブツブツ.txt"
+assertHttpRequestEquals "GET" "b/クズ箱/ゴミ.txt" "data/bucket-1/b/クズ箱/ゴミ.txt"
+assertHttpRequestEquals "GET" "системы/system.txt" "data/bucket-1/системы/system.txt"
 
 if [ "${allow_directory_list}" == "1" ]; then
   assertHttpRequestEquals "GET" "/" "200"

--- a/test/unit/s3gateway_test.js
+++ b/test/unit/s3gateway_test.js
@@ -231,7 +231,7 @@ function testSignatureV4Cache() {
 
 function testEditAmzHeaders() {
     var r = {
-        "headersOut" : {
+        "headersOut": {
             "Accept-Ranges": "bytes",
             "Content-Length": 42,
             "Content-Security-Policy": "block-all-mixed-content",
@@ -239,7 +239,10 @@ function testEditAmzHeaders() {
             "X-Amz-Bucket-Region": "us-east-1",
             "X-Amz-Request-Id": "166539E18A46500A",
             "X-Xss-Protection": "1; mode=block"
-        }
+        },
+        "variables": {
+            "uri_path": "/a/c/ramen.jpg"
+        },
     }
 
     r.log = function(msg) {
@@ -254,6 +257,33 @@ function testEditAmzHeaders() {
         }
     }
 }
+
+function testEditAmzHeadersHeadDirectory() {
+        var r = {
+                "method": "HEAD",
+                "headersOut" : {
+                    "Content-Security-Policy": "block-all-mixed-content",
+                        "Content-Type": "application/xml",
+                        "Server": "AmazonS3",
+                        "X-Amz-Bucket-Region": "us-east-1",
+                        "X-Amz-Request-Id": "166539E18A46500A",
+                        "X-Xss-Protection": "1; mode=block"
+                },
+            "variables": {
+                    "uri_path": "/a/c/"
+                },
+        }
+
+            r.log = function(msg) {
+                    console.log(msg);
+                }
+
+            s3gateway.editAmzHeaders(r);
+
+            if (r.headersOut.length > 0) {
+                throw "all headers were not stripped from request";
+            }
+    }
 
 function testEscapeURIPathPreservesDoubleSlashes() {
     var doubleSlashed = '/testbucketer2/foo3//bar3/somedir/license';
@@ -275,6 +305,7 @@ function test() {
     testSignatureV4();
     testSignatureV4Cache();
     testEditAmzHeaders();
+    testEditAmzHeadersHeadDirectory();
     testEscapeURIPathPreservesDoubleSlashes();
 }
 


### PR DESCRIPTION
Directories with unicode characters would not list correctly
and when using v4 signatures files with unicode characters
could not be downloaded.

This change fixes the problems with double encoding of strings
and adds additional tests.