### PR TITLE
Fix auth v4 for directory listing

### DIFF
--- a/common/etc/nginx/include/s3gateway.js
+++ b/common/etc/nginx/include/s3gateway.js
@@ -348,7 +348,7 @@ function s3uri(r) {
     if (allow_listing) {
         var queryParams = _s3DirQueryParams(uriPath, r.method);
         if (queryParams.length > 0) {
-            path = basePath + '/?' + queryParams;
+            path = basePath + '?' + queryParams;
         } else {
             path = basePath + uriPath;
         }


### PR DESCRIPTION
I was getting `SignatureDoesNotMatch` errors when using directory
listing with v4 authentication. Seems like the problem was
the requests were sent with trailing `/` while the signature
was calculated without it.

It doesn't seem we need the trailing space there (I have checked
only with Ceph S3 API, so more testing with AWS welcome), but seems
like the code should be broken for every back-end, unless I'm missing
something.