### PR TITLE
Support for regional STS endpoint detection

### DIFF
--- a/common/etc/nginx/include/s3gateway.js
+++ b/common/etc/nginx/include/s3gateway.js
@@ -1048,7 +1048,7 @@ async function _fetchWebIdentityCredentials(r) {
         if (sts_regional === 'regional') {
             var region = process.env['AWS_REGION'];
             if (region) {
-                sts_endpoint = 'https://sts.' + region + '.amazonaws.com';
+                sts_endpoint = `https://sts.${region}.amazonaws.com`;
             } else {
                 throw 'Missing required AWS_REGION env variable';
             }
@@ -1059,7 +1059,7 @@ async function _fetchWebIdentityCredentials(r) {
 
     var token = fs.readFileSync(process.env['AWS_WEB_IDENTITY_TOKEN_FILE']);
     
-    var params = "Version=2011-06-15&Action=AssumeRoleWithWebIdentity&RoleArn=" + arn + "&RoleSessionName=" + name + "&WebIdentityToken=" + token;
+    var params = `Version=2011-06-15&Action=AssumeRoleWithWebIdentity&RoleArn=${arn}&RoleSessionName=${name}&WebIdentityToken=${token}`;
 
     var response = await ngx.fetch(sts_endpoint + "?" + params, {
         headers: {

--- a/common/etc/nginx/include/s3gateway.js
+++ b/common/etc/nginx/include/s3gateway.js
@@ -1044,8 +1044,16 @@ async function _fetchWebIdentityCredentials(r) {
 
     var sts_endpoint = process.env['STS_ENDPOINT'];
     if (!sts_endpoint) {
+        // On EKS, the ServiceAccount can be annotated with 'eks.amazonaws.com/sts-regional-endpoints' to control
+        // the usage of regional endpoints. We are using the same standard environment variable here as
+        // the AWS SDK. This is with the exception of replacing the value `legacy` with `global` to match
+        // what EKS sets the variable to.
+        // https://docs.aws.amazon.com/sdkref/latest/guide/feature-sts-regionalized-endpoints.html
+        // https://docs.aws.amazon.com/eks/latest/userguide/configure-sts-endpoint.html
         var sts_regional = process.env['AWS_STS_REGIONAL_ENDPOINTS'] || 'global';
         if (sts_regional === 'regional') {
+            // STS regional endpoints can be derived from the region's name.
+            // https://docs.aws.amazon.com/general/latest/gr/sts.html
             var region = process.env['AWS_REGION'];
             if (region) {
                 sts_endpoint = `https://sts.${region}.amazonaws.com`;
@@ -1053,6 +1061,7 @@ async function _fetchWebIdentityCredentials(r) {
                 throw 'Missing required AWS_REGION env variable';
             }
         } else {
+            // This is the default global endpoint
             sts_endpoint = 'https://sts.amazonaws.com';
         }
     }

--- a/common/etc/nginx/include/s3gateway.js
+++ b/common/etc/nginx/include/s3gateway.js
@@ -1041,7 +1041,22 @@ async function _fetchEC2RoleCredentials() {
 async function _fetchWebIdentityCredentials(r) {
     var arn   = process.env['AWS_ROLE_ARN'];
     var name  = process.env['HOSTNAME'] || 'nginx-s3-gateway';
-    var sts_endpoint = process.env['STS_ENDPOINT'] || 'https://sts.amazonaws.com';
+
+    var sts_endpoint = process.env['STS_ENDPOINT'];
+    if (!sts_endpoint) {
+        var sts_regional = process.env['AWS_STS_REGIONAL_ENDPOINTS'] || 'global';
+        if (sts_regional === 'regional') {
+            var region = process.env['AWS_REGION'];
+            if (region) {
+                sts_endpoint = 'https://sts.' + region + '.amazonaws.com';
+            } else {
+                throw 'Missing required AWS_REGION env variable';
+            }
+        } else {
+            sts_endpoint = 'https://sts.amazonaws.com';
+        }
+    }
+
     var token = fs.readFileSync(process.env['AWS_WEB_IDENTITY_TOKEN_FILE']);
     
     var params = "Version=2011-06-15&Action=AssumeRoleWithWebIdentity&RoleArn=" + arn + "&RoleSessionName=" + name + "&WebIdentityToken=" + token;

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -268,6 +268,7 @@ modified.
   aws cloudformation delete-stack \
     --stack-name nginx-s3-gateway
   ```
+
 ## Running on EKS with IAM roles for service accounts
 
 If you are planning to use the container image on an EKS cluster, you can use a [service account]((https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)) which can assume a role using [AWS Security Token Service](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html).


### PR DESCRIPTION
The appropriate STS endpoint gets detected via the `AWS_STS_REGIONAL_ENDPOINTS` and `AWS_REGION` env variables.

This change is untested as I don't have an environment available for testing currently.