### PR TITLE
Fix credentials caching

### DIFF
--- a/common/etc/nginx/include/s3gateway.js
+++ b/common/etc/nginx/include/s3gateway.js
@@ -882,7 +882,7 @@ function _require_env_var(envVarName) {
  *
  * @type {number}
  */
-var maxValidityOffsetMs = 4.5 * 60 * 100;
+var maxValidityOffsetMs = 4.5 * 60 * 1000;
 
 /**
  * Get the credentials needed to create AWS signatures in order to authenticate
@@ -918,7 +918,8 @@ async function fetchCredentials(r) {
     }
 
     if (current) {
-        var exp = new Date(current.expiration).getTime() - maxValidityOffsetMs;
+        // AWS returns Unix timestamps in seconds, but in Date constructor we should provide timestamp in milliseconds
+        var exp = new Date(current.expiration * 1000).getTime() - maxValidityOffsetMs;
         if (now.getTime() < exp) {
             r.return(200);
             return;


### PR DESCRIPTION
I found two issues while I was trying to figure out what's wrong with credentials caching:
- Date object was constructed with Unix timestamp value, while it was assuming that it would be milliseconds timestamp, so i added `* 1000`
- Based on comment it seems that `maxValidityOffsetMs` should be 4.5 minutes, but it was 0.45 minute