### PR TITLE
Fix 404 errors for filenames containing certain characters

### DIFF
--- a/common/etc/nginx/include/s3gateway.js
+++ b/common/etc/nginx/include/s3gateway.js
@@ -358,7 +358,7 @@ function s3uri(r) {
         }
     } else {
         if (provide_index_page  && _isDirectory(uriPath) ) {
-               uriPath += INDEX_PAGE;
+            uriPath += INDEX_PAGE;
         }
         path = basePath + uriPath;
     }
@@ -571,6 +571,7 @@ function _buildSignatureV4(r, amzDatetime, eightDigitDate, creds, bucket, region
     } else {
         uri = _escapeURIPath(s3uri(r));
     }
+
     var canonicalRequest = _buildCanonicalRequest(method, uri, queryParams, host, amzDatetime, creds.sessionToken);
 
     _debug_log(r, 'AWS v4 Auth Canonical Request: [' + canonicalRequest + ']');
@@ -782,6 +783,31 @@ function _padWithLeadingZeros(num, size) {
 }
 
 /**
+ * Adds additional encoding to a URI component
+ *
+ * @param string {string} string to encode
+ * @returns {string} an encoded string
+ * @private
+ */
+function _encodeURIComponent(string) {
+    var additionalEscapes = [
+        [/\(/g, '%28'],
+        [/\)/g, '%29'],
+        [/\!/g, '%21'],
+        [/\*/g, '%2A'],
+        [/\'/g, '%27']
+    ];
+
+    var encoded = encodeURIComponent(string);
+
+    additionalEscapes.forEach(function (replace) {
+        encoded = encoded.replace(replace[0], replace[1]);
+    });
+
+    return encoded;
+}
+
+/**
  * Escapes the path portion of a URI without escaping the path separator
  * characters (/).
  *
@@ -795,7 +821,7 @@ function _escapeURIPath(uri) {
     let components = [];
 
     decodedUri.split('/').forEach(function (item, i) {
-        components[i] = encodeURIComponent(item);
+        components[i] = _encodeURIComponent(item);
     });
 
     return components.join('/');
@@ -1038,6 +1064,7 @@ export default {
     // These functions do not need to be exposed, but they are exposed so that
     // unit tests can run against them.
     _padWithLeadingZeros,
+    _encodeURIComponent,
     _eightDigitDate,
     _amzDatetime,
     _splitCachedValues,

--- a/test/data/bucket-1/b/c/'(1).txt
+++ b/test/data/bucket-1/b/c/'(1).txt
@@ -1,0 +1,1 @@
+In the midst of movement and chaos, keep stillness inside of you.

--- a/test/integration/test_api.sh
+++ b/test/integration/test_api.sh
@@ -158,6 +158,7 @@ assertHttpRequestEquals "HEAD" "b//e.txt" "200"
 # Weird filenames
 assertHttpRequestEquals "HEAD" "b/c/=" "200"
 assertHttpRequestEquals "HEAD" "b/c/@" "200"
+assertHttpRequestEquals "HEAD" "b/c/'(1).txt" "200"
 assertHttpRequestEquals "HEAD" "%D1%81%D0%B8%D1%81%D1%82%D0%B5%D0%BC%D1%8B/%25bad%25file%25name%25" "200"
 if [ ${is_windows} == "0" ]; then
   assertHttpRequestEquals "HEAD" "a/c/あ" "200"
@@ -221,6 +222,7 @@ assertHttpRequestEquals "GET" "a.txt" "data/bucket-1/a.txt"
 assertHttpRequestEquals "GET" "a.txt?some=param&that=should&be=stripped#aaah" "data/bucket-1/a.txt"
 assertHttpRequestEquals "GET" "b/c/d.txt" "data/bucket-1/b/c/d.txt"
 assertHttpRequestEquals "GET" "b/c/=" "data/bucket-1/b/c/="
+assertHttpRequestEquals "GET" "b/c/'(1).txt" "data/bucket-1/b/c/'(1).txt"
 assertHttpRequestEquals "GET" "b/e.txt" "data/bucket-1/b/e.txt"
 assertHttpRequestEquals "GET" "%D1%81%D0%B8%D1%81%D1%82%D0%B5%D0%BC%D1%8B/%25bad%25file%25name%25" "data/bucket-1/системы/%bad%file%name%"
 


### PR DESCRIPTION
Hi,

I was experiencing 404 errors when using the gateway with filenames which mainly contained brackets `()` (#53). This pull request attempts to fix that by applying additional character encodings to the native `encodeURIComponent` function that is being called during SigV4 creation when the URI path is being escaped.

I've added tests which have passed for me successfully. I've also tested the built docker image with AWS S3, and everything appears to work fine for me there as well.

I'm not too familiar with the process of handling S3 requests, so any input, changes or suggestions are very much welcome.

Summed up, this PR attempts to fix the 404 errors encountered when filenames contain any of these characters: `()'!*`.