### PR TITLE
Add support for unpriviledged non-root image container

### DIFF
--- a/Dockerfile.latest-unpriviledged
+++ b/Dockerfile.latest-unpriviledged
@@ -1,0 +1,21 @@
+# This container images makes the necessary modifications in the
+# inherited image (which could be OSS NGINX or NGINX Plus) in order
+# to allow running NGINX S3 Gateway as a non root user.
+# Steps are based on the official unpriviledged container:
+# https://github.com/nginxinc/docker-nginx-unprivileged/blob/main/Dockerfile-debian.template
+FROM nginx-s3-gateway
+
+# Implement changes required to run NGINX as an unprivileged user
+RUN sed -i "/^server {/a \    listen       8080;" /etc/nginx/templates/default.conf.template \
+    && sed -i '/user  nginx;/d' /etc/nginx/nginx.conf \
+    && sed -i 's,/var/run/nginx.pid,/tmp/nginx.pid,' /etc/nginx/nginx.conf \
+    && sed -i "/^http {/a \    proxy_temp_path /tmp/proxy_temp;\n    client_body_temp_path /tmp/client_temp;\n    fastcgi_temp_path /tmp/fastcgi_temp;\n    uwsgi_temp_path /tmp/uwsgi_temp;\n    scgi_temp_path /tmp/scgi_temp;\n" /etc/nginx/nginx.conf \
+# Nginx user must own the cache and etc directory to write cache and tweak the nginx config
+    && chown -R nginx:0 /var/cache/nginx \
+    && chmod -R g+w /var/cache/nginx \
+    && chown -R nginx:0 /etc/nginx \
+    && chmod -R g+w /etc/nginx
+
+EXPOSE 8080
+
+USER nginx

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ Dockerfile.buildkit.plus         Dockerfile with the same configuration as Docke
                                  with support for hiding secrets using Docker's Buildkit
 Dockerfile.latest-njs            Dockerfile that inherits from the last build of the gateway and
                                  then builds and installs the latest version of njs from source
+Dockerfile.latest-unpriviledged  Dockerfiles that inherits from the last build of the gateway and
+                                 makes the necessary modifications to allow running the container
+                                 as a non root, unpriviledged user.
 settings.example                 Docker env file example
 standalone_ubuntu_oss_install.sh install script that will install the gateway as a Systemd service
 test.sh                          test launcher

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -148,6 +148,17 @@ docker run --env-file ./settings --publish 80:80 --name nginx-s3-gateway \
     nginx-s3-gateway:oss
 ```
 
+In the same way, if you want to use NGINX OSS container image as a non-root, unpriviledged user,
+you can build it as follows:
+```
+docker build --file Dockerfile.latest-unpriviledged --tag nginx-s3-gateway --tag nginx-s3-gateway:latest-unpriviledged-oss .
+```
+And run the image binding the container port 8080 to 80 in the host like:
+```
+docker run --env-file ./settings --publish 80:8080 --name nginx-s3-gateway \
+    nginx-s3-gateway:latest-unpriviledged-oss
+```
+
 ### Building the NGINX Plus Container Image
 
 In order to build the NGINX Plus container image, copy your NGINX Plus 


### PR DESCRIPTION
Running container images with a non-root user provides additional security against vulnerabilities, and some containers orchestrators such as Openshift enforce this security policy making official regular nginx not compatible out of the box.

These changes, based on ['nginxinc/docker-nginx-unprivileged'](https://github.com/nginxinc/docker-nginx-unprivileged), modify the parent image 'Dockerfile.oss' to allow nginx to execute with a non-root user. 
Basic changes include:
* The default NGINX listen port is now `8080` instead of `80` (this is no longer necessary as of Docker `20.03` but it's still required in other container runtimes).
* The default NGINX user directive in `/etc/nginx/nginx.conf` has been removed.
* The default NGINX PID has been moved from `/var/run/nginx.pid` to `/tmp/nginx.pid`.
* Change `*_temp_path` variables to `/tmp/*`.
