### PR TITLE
Fix no such directory for nginx.service.d

### DIFF
--- a/standalone_ubuntu_oss_install.sh
+++ b/standalone_ubuntu_oss_install.sh
@@ -205,6 +205,7 @@ EOF
 chmod +x /usr/local/bin/template_nginx_config.sh
 
 echo "▶ Reconfiguring systemd for S3 Gateway"
+mkdir -p /etc/systemd/system/nginx.service.d
 cat > /etc/systemd/system/nginx.service.d/override.conf << 'EOF'
 [Service]
 EnvironmentFile=/etc/nginx/environment


### PR DESCRIPTION
**Problem:**
- When running `standalone_ubuntu_oss_install.sh` for `nginx-s3-gateway` as a Systemd Service, the following error occurs:
  ```bash
  standalone_ubuntu_oss_install1.sh: line 224: /etc/systemd/system/nginx.service.d/override.conf: No such file or directory
  ```
- Root-cause: `/etc/systemd/system/nginx.service.d/` does not exist.

**Fix:**
- Create a directory of `etc/systemd/system/nginx.service.d/` prior to running the following script:
   ```
  cat > /etc/systemd/system/nginx.service.d/override.conf << 'EOF'
  [Service]
  EnvironmentFile=/etc/nginx/environment
  ExecStartPre=/usr/local/bin/template_nginx_config.sh
  EOF
   ```