### PR TITLE
Bugfix: Handle non-unixtime expiration

### DIFF
--- a/common/etc/nginx/include/s3gateway.js
+++ b/common/etc/nginx/include/s3gateway.js
@@ -988,8 +988,9 @@ async function fetchCredentials(r) {
     }
 
     if (current) {
-        // AWS returns Unix timestamps in seconds, but in Date constructor we should provide timestamp in milliseconds
-        const exp = new Date(current.expiration * 1000).getTime() - maxValidityOffsetMs;
+        // If AWS returns a Unix timestamp it will be in seconds, but in Date constructor we should provide timestamp in milliseconds
+        const expireAt = typeof current.expiration == 'number' ? current.expiration * 1000 : current.expiration
+        const exp = new Date(expireAt).getTime() - maxValidityOffsetMs;
         if (NOW.getTime() < exp) {
             r.return(200);
             return;

--- a/common/etc/nginx/include/s3gateway.js
+++ b/common/etc/nginx/include/s3gateway.js
@@ -989,6 +989,7 @@ async function fetchCredentials(r) {
 
     if (current) {
         // If AWS returns a Unix timestamp it will be in seconds, but in Date constructor we should provide timestamp in milliseconds
+        // In some situations (including EC2 and Fargate) current.expiration will be an RFC 3339 string - see https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#instance-metadata-security-credentials
         const expireAt = typeof current.expiration == 'number' ? current.expiration * 1000 : current.expiration
         const exp = new Date(expireAt).getTime() - maxValidityOffsetMs;
         if (NOW.getTime() < exp) {


### PR DESCRIPTION
At least in Fargate, the instance role credentials have a human-readable expiration time, not a unix timestamp (for example - `'2023-02-25T19:56:26Z'`).

As a result, we get `NaN` when multiplying this value by 1000 which breaks the expiry checking logic. This leads to credentials being fetched on every request, which is slow and may well exceed the limits of the metadata endpoint.

My proposed solution is to only do the multiplication if our expiration time is numeric, on the assumption that this must be true in some contexts. `Date` can accept the string expiration times directly with no additional processing.

I've only tested this in Fargate - it might be worth ensuring that this still works for credentials in other contexts.