### PR TITLE
fix: k8s error exec /docker-entrypoint.sh: exec format error

### DIFF
--- a/common/docker-entrypoint.d/00-check-for-required-env.sh
+++ b/common/docker-entrypoint.d/00-check-for-required-env.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 #
 #  Copyright 2020 F5 Networks
 #

--- a/common/docker-entrypoint.sh
+++ b/common/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 #
 #  Copyright 2020 F5 Networks
 #
@@ -16,8 +16,6 @@
 #
 
 # vim:sw=4:ts=4:et
-
-set -e
 
 parseBoolean() {
   case "$1" in

--- a/standalone_ubuntu_oss_install.sh
+++ b/standalone_ubuntu_oss_install.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 set -o errexit   # abort on nonzero exit status
 set -o pipefail  # don't hide errors within pipes
@@ -213,7 +213,7 @@ chown root:root /etc/nginx/environment
 chmod og-rwx /etc/nginx/environment
 
 cat > /usr/local/bin/template_nginx_config.sh << 'EOF'
-#!/usr/bin/env bash
+#!/bin/bash
 
 ME=$(basename $0)
 

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 #
 #  Copyright 2020 F5 Networks

--- a/test/integration/test_api.sh
+++ b/test/integration/test_api.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 
 #
 #  Copyright 2020 F5 Networks


### PR DESCRIPTION
hello, i change the shebang of the shell scripts and now the image run without errors on k8s aws 
error exec /docker-entrypoint.sh: exec format error (mac m1 with FROM --platform=linux/amd64)

Regards