### PR TITLE
Add missing CORS headers for 404 status code

### DIFF
--- a/common/etc/nginx/templates/default.conf.template
+++ b/common/etc/nginx/templates/default.conf.template
@@ -310,6 +310,10 @@ server {
     }
 
     location @error404 {
+        # The CORS configuration needs to be imported in several places in order for
+        # it to be applied within different contexts.
+        include /etc/nginx/conf.d/gateway/cors.conf;
+
         return 404;
     }
 


### PR DESCRIPTION
When file not exist in s3 nginx return 404 response without CORS headers.