### PR TITLE
chore: small fixes to test scripts and README for clarity

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -55,7 +55,7 @@ additional modules.
 
 ## Testing
 
-Automated tests require `docker`, `docker-compose`, `curl`, `mc` and `md5sum` to be
+Automated tests require `docker`, `docker-compose`, `curl`, and `mc` (the minio [cli tool](https://github.com/penpyt/asdf-mc)) to be
 installed. To run all unit tests and integration tests, run the following command.
 If you invoke the test script with a plus parameter, you will need to add your
 NGINX repository keys to the `plus/etc/ssl/nginx` directory

--- a/test.sh
+++ b/test.sh
@@ -19,6 +19,14 @@
 set -o errexit   # abort on nonzero exit status
 set -o pipefail  # don't hide errors within pipes
 
+### Overview
+# This script does three things:
+# 1. Sets up the test environment using docker-compose and creates test data
+# 2. Runs unit tests in the ./test/unit directory which are written in Javascript
+# 3. Runs integration tests in ./test/integration which are written in bash
+#
+# The integration test runneer
+
 nginx_server_proto="http"
 nginx_server_host="localhost"
 nginx_server_port="8989"
@@ -378,6 +386,16 @@ runUnitTestWithSessionToken "awssig4_test.js"
 runUnitTestWithSessionToken "s3gateway_test.js"
 
 ### INTEGRATION TESTS
+# The arguments correspond to flags given to the integration test runner
+# integration_test 2 0 0 0
+# AWS_SIGS_VERSION=$1 : any valid AWS Sigs version. Eg: 2
+# ALLOW_DIRECTORY_LIST=$2 : boolean value denoted by 0 or 1
+# PROVIDE_INDEX_PAGE=$3 : boolean value denoted by 0 or 1
+# APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=$4 : boolean value denoted by 0 or 1
+#
+# These are various invocations of ./test/integration/test_api.sh
+# where the flags represent different configurations for that single test
+# file.
 
 integration_test_data
 

--- a/test.sh
+++ b/test.sh
@@ -25,7 +25,9 @@ set -o pipefail  # don't hide errors within pipes
 # 2. Runs unit tests in the ./test/unit directory which are written in Javascript
 # 3. Runs integration tests in ./test/integration which are written in bash
 #
-# The integration test runneer
+# The integration test runner uses a series of flags to test different configuration
+# values. See the function definition for `integration_test` in this file
+# for details on the parameters and their allowed values.
 
 nginx_server_proto="http"
 nginx_server_host="localhost"
@@ -388,10 +390,10 @@ runUnitTestWithSessionToken "s3gateway_test.js"
 ### INTEGRATION TESTS
 # The arguments correspond to flags given to the integration test runner
 # integration_test 2 0 0 0
-# AWS_SIGS_VERSION=$1 : any valid AWS Sigs version. Eg: 2
-# ALLOW_DIRECTORY_LIST=$2 : boolean value denoted by 0 or 1
-# PROVIDE_INDEX_PAGE=$3 : boolean value denoted by 0 or 1
-# APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=$4 : boolean value denoted by 0 or 1
+# AWS_SIGS_VERSION=$1 : any valid AWS Sigs version. Supported values are `2` or `4`
+# ALLOW_DIRECTORY_LIST=$2 : boolean value denoted by `0` or `1`
+# PROVIDE_INDEX_PAGE=$3 : boolean value denoted by `0` or `1`
+# APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=$4 : boolean value denoted by `0` or `1`
 #
 # These are various invocations of ./test/integration/test_api.sh
 # where the flags represent different configurations for that single test


### PR DESCRIPTION
# What
Small changes to the documentation and test runner comments to improve the integration test writing experience.

Changes:

1. Clarified the name of the minio tool required since it took a few minutes of searching
2. Documented the purpose and acceptable values of the many params to the integration test runner function