### PR TITLE
Fix error messages for missing dependencies, allow test suite to run on MacOS by supporting `md5`

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -55,7 +55,7 @@ additional modules.
 
 ## Testing
 
-Automated tests require `docker`, `docker-compose`, `curl`, and `mc` (the minio [cli tool](https://github.com/penpyt/asdf-mc)) to be
+Automated tests require `docker`, `docker-compose`, `curl`, `md5sum` (or `md5` on MacOS), and `mc` (the minio [cli tool](https://github.com/penpyt/asdf-mc)) to be
 installed. To run all unit tests and integration tests, run the following command.
 If you invoke the test script with a plus parameter, you will need to add your
 NGINX repository keys to the `plus/etc/ssl/nginx` directory

--- a/test.sh
+++ b/test.sh
@@ -131,7 +131,7 @@ e "${startup_message}"
 
 set -o nounset   # abort on unbound variable
 
-docker_cmd="$(command -v docker)"
+docker_cmd="$(command -v docker || true)"
 if ! [ -x "${docker_cmd}" ]; then
   e "required dependency not found: docker not found in the path or not executable"
   exit ${no_dep_exit_code}
@@ -147,7 +147,7 @@ else
 fi
 e "Using Docker Compose command: ${docker_compose_cmd}"
 
-curl_cmd="$(command -v curl)"
+curl_cmd="$(command -v curl || true)"
 if ! [ -x "${curl_cmd}" ]; then
   e "required dependency not found: curl not found in the path or not executable"
   exit ${no_dep_exit_code}

--- a/test/integration/test_api.sh
+++ b/test/integration/test_api.sh
@@ -58,16 +58,28 @@ if [ -z "${test_dir}" ]; then
   e "missing second parameter: path to test data directory"
 fi
 
-curl_cmd="$(command -v curl)"
+curl_cmd="$(command -v curl || true)"
 if ! [ -x "${curl_cmd}" ]; then
   e "required dependency not found: curl not found in the path or not executable"
   exit ${no_dep_exit_code}
 fi
 
-checksum_cmd="$(command -v md5sum)"
-if ! [ -x "${curl_cmd}" ]; then
+# Allow for MacOS which does not support "md5sum"
+# but has "md5 -r" which can be substituted
+checksum_cmd="$(command -v md5sum || true)"
+checksum_cmd="$(command -v md5 || true)"
+
+if ! [ -x "${checksum_cmd}" ]; then
   e "required dependency not found: md5sum not found in the path or not executable"
   exit ${no_dep_exit_code}
+fi
+
+# If we are using the `md5` executable
+# then use the -r flag which makes it behave the same as `md5sum`
+# this is done after the `-x` check for ability to execute
+# since it will not pass with the flag
+if [[ $checksum_cmd =~ \/md5$ ]]; then
+  checksum_cmd="${checksum_cmd} -r"
 fi
 
 assertHttpRequestEquals() {

--- a/test/integration/test_api.sh
+++ b/test/integration/test_api.sh
@@ -66,8 +66,7 @@ fi
 
 # Allow for MacOS which does not support "md5sum"
 # but has "md5 -r" which can be substituted
-checksum_cmd="$(command -v md5sum || true)"
-checksum_cmd="$(command -v md5 || true)"
+checksum_cmd="$(command -v md5sum || command -v md5 || true)"
 
 if ! [ -x "${checksum_cmd}" ]; then
   e "required dependency not found: md5sum not found in the path or not executable"


### PR DESCRIPTION
# What
Fix error messages for missing dependencies, allow test suite to run on MacOS by supporting `md5`

## Dependency Checks
There were some checks like this:

```bash
curl_cmd="$(command -v curl)"
if ! [ -x "${curl_cmd}" ]; then
  e "required dependency not found: curl not found in the path or not executable"
  exit ${no_dep_exit_code}
fi
```

However, `command -v` exits with an error if the command does not exist. This results in the nice error message not being shown.

The solution is to avoid the assignment of the variable erroring and instead relying on the executability check to make sure we have the right thing

## `md5` compatibility
The test script depends on `md5sum` which is not available on MacOS. Thus, tests would fail at the start when run on MacOS.
MacOS has a tool called `md5`, which when called with the `-r` flag which reverses the format of the output.

