### PR TITLE
[Je issue/164

### DIFF
--- a/common/etc/nginx/include/s3gateway.js
+++ b/common/etc/nginx/include/s3gateway.js
@@ -333,8 +333,12 @@ function redirectToS3(r) {
 
 function trailslashControl(r) {
     if (APPEND_SLASH) {
+        // For the purposes of understanding whether this is a directory,
+        // consider the uri without query params or anchors
+        const path = r.variables.uri_path.split(/[?#]/)[0];
+
         const hasExtension = /\/[^.\/]+\.[^.]+$/;
-        if (!hasExtension.test(r.variables.uri_path)  && !_isDirectory(r.variables.uri_path)){
+        if (!hasExtension.test(path)  && !_isDirectory(path)){
             return r.internalRedirect("@trailslash");
         }
     }
@@ -447,6 +451,8 @@ function _escapeURIPath(uri) {
  * @private
  */
 function _isDirectory(path) {
+    // if (!path) return false;
+    // str.slice(-1);
     if (path === undefined) {
         return false;
     }

--- a/common/etc/nginx/include/s3gateway.js
+++ b/common/etc/nginx/include/s3gateway.js
@@ -322,9 +322,9 @@ function redirectToS3(r) {
 
     if (isDirectoryListing && (r.method === 'GET' || r.method === 'HEAD')) {
         r.internalRedirect("@s3PreListing");
-    } else if ( PROVIDE_INDEX_PAGE == true ) {
+    } else if (PROVIDE_INDEX_PAGE === true) {
         r.internalRedirect("@s3");
-    } else if ( !ALLOW_LISTING && !PROVIDE_INDEX_PAGE && uriPath == "/" ) {
+    } else if (!ALLOW_LISTING && !PROVIDE_INDEX_PAGE && uriPath === "/") {
        r.internalRedirect("@error404");
     } else {
         r.internalRedirect("@s3");
@@ -353,22 +353,20 @@ async function loadContent(r) {
         r.internalRedirect("@s3Directory");
         return;
     }
-    const url = s3uri(r);
+    const uri = s3uri(r);
     let reply = await ngx.fetch(
-        `http://127.0.0.1:80${url}`
+        `http://127.0.0.1:80${uri}`
     );
 
-    if (reply.status == 200) {
-        // found index.html, so redirect to it
-        r.internalRedirect(r.variables.request_uri + INDEX_PAGE);
-    } else if (reply.status == 404) {
-        // else just list the contents of the directory
+    if (reply.status === 200) {
+        utils.debug_log(r, `Found index file, redirecting to: ${uri}`);
+        r.internalRedirect(uri);
+    } else if (reply.status === 404) {
+        // As there was no index file found, just list the contents of the directory
         r.internalRedirect("@s3Directory");
     } else {
         r.internalRedirect("@error500");
     }
-
-    return;
 }
 
 /**

--- a/common/etc/nginx/include/s3gateway.js
+++ b/common/etc/nginx/include/s3gateway.js
@@ -451,18 +451,9 @@ function _escapeURIPath(uri) {
  * @private
  */
 function _isDirectory(path) {
-    // if (!path) return false;
-    // str.slice(-1);
-    if (path === undefined) {
-        return false;
-    }
-    const len = path.length;
+    if (!path) return false;
 
-    if (len < 1) {
-        return false;
-    }
-
-    return path.charAt(len - 1) === '/';
+    return path.slice(-1) === '/';
 }
 
 /**

--- a/common/etc/nginx/templates/default.conf.template
+++ b/common/etc/nginx/templates/default.conf.template
@@ -326,7 +326,7 @@ server {
 
     location @trailslash {
         # 302 to request without slashes
-        rewrite ^ $scheme://$http_host$request_uri/ redirect;
+        rewrite ^ $scheme://$http_host$uri/$is_args$query_string redirect;
     }
 
     # Provide a hint to the client on 405 errors of the acceptable request methods

--- a/test.sh
+++ b/test.sh
@@ -411,6 +411,11 @@ integration_test 2 1 0 0
 
 compose stop nginx-s3-gateway # Restart with new config
 
+p "Testing API with AWS Signature V2 and allow directory listing on and append slash and allow index"
+integration_test 2 1 1 1
+
+compose stop nginx-s3-gateway # Restart with new config
+
 p "Testing API with AWS Signature V2 and static site on"
 integration_test 2 0 1 0
 

--- a/test/data/bucket-1/test/index.html
+++ b/test/data/bucket-1/test/index.html
@@ -1,0 +1,1 @@
+<h1>This is an index page of the d directory</h1>

--- a/test/integration/test_api.sh
+++ b/test/integration/test_api.sh
@@ -288,6 +288,15 @@ assertHttpRequestEquals "GET" "/statichost/noindexdir/multipledir/" "data/bucket
   assertHttpRequestEquals "GET" "/statichost" "data/bucket-1/statichost/index.html"
   assertHttpRequestEquals "GET" "/statichost/noindexdir/multipledir" "data/bucket-1/statichost/noindexdir/multipledir/index.html"
   fi
+
+  if [ "${allow_directory_list}" == "1" ]; then
+    if [ "$append_slash" == "1" ]; then
+      assertHttpRequestEquals "GET" "test" "200"
+      assertHttpRequestEquals "GET" "test/" "200"
+      assertHttpRequestEquals "GET" "test?foo=bar" "200"
+      assertHttpRequestEquals "GET" "test/?foo=bar" "200"
+    fi
+  fi
 fi
 
 if [ "${allow_directory_list}" == "1" ]; then
@@ -299,7 +308,9 @@ if [ "${allow_directory_list}" == "1" ]; then
   assertHttpRequestEquals "GET" "%D1%81%D0%B8%D1%81%D1%82%D0%B5%D0%BC%D1%8B/" "200"
   assertHttpRequestEquals "GET" "системы/" "200"
   if [ "$append_slash" == "1" ]; then
-    assertHttpRequestEquals "GET" "b" "302"
+    if [ "${index_page}" == "0" ]; then
+      assertHttpRequestEquals "GET" "b" "302"
+    fi
   else
     assertHttpRequestEquals "GET" "b" "404"
   fi


### PR DESCRIPTION
# What
This PR presents some additional ideas to be considered for addition to https://github.com/nginxinc/nginx-s3-gateway/pull/167 aiming to fix issue https://github.com/nginxinc/nginx-s3-gateway/issues/164

## Expectations
This solution assumes that the following configuration options are set to true
* `APPEND_SLASH_FOR_POSSIBLE_DIRECTORY`
* `PROVIDE_INDEX_PAGE`
* `ALLOW_DIRECTORY_LIST`

Given a folder `test` **with** an `index.html` present in the directory, the `index.html` should be served for:
* `/test`
* `/test/`
* `/test?foo=bar`
* `/test/?foo=bar`

Given a folder `test` **WITHOUT** an `index.html` present in the directory, files in the directory should be listed for:
* `/test`
* `/test/`
* `/test?foo=bar`
* `/test/?foo=bar`

## Notes
* The `@trailslash` was rewriting to `$request_uri` with a trailing slash on the end.  In the case of `/test?foo=bar` we'd wind up with `/test?foo=bar/` which when combined with the other changes led to a rewrite loop
* Changed the check for directory or file to consider the path without anchor or querystring
* I added yet another integration test suite and shuffled around the conditionals that maybe make the tests even more confusing - but do cover this case.