### PR TITLE
fix: gracefully handle comments in resolv.conf. Fixes #171

### DIFF
--- a/common/docker-entrypoint.sh
+++ b/common/docker-entrypoint.sh
@@ -32,16 +32,11 @@ parseBoolean() {
 
 # This line is an addition to the NGINX Docker image's entrypoint script.
 if [ -z ${DNS_RESOLVERS+x} ]; then
-  resolvers=""
-  for ip in $(grep nameserver /etc/resolv.conf | cut -d' ' -f2 | xargs)
-  do
-    if echo "${ip}" | grep -q ':'; then
-      resolvers="$resolvers [${ip}]"
-    else
-      resolvers="$resolvers $ip"
-    fi
-  done
-  export DNS_RESOLVERS="${resolvers}"
+   # This method of pulling individual nameservers from
+   # /etc/resolv.conf taken from the entrypoint script in the
+   # official docker image.
+   # https://github.com/nginxinc/docker-nginx/blob/master/entrypoint/15-local-resolvers.envsh
+  export DNS_RESOLVERS="$(awk 'BEGIN{ORS=" "} $1=="nameserver" {print $2}' /etc/resolv.conf)"
 fi
 
 # Normalize the CORS_ENABLED environment variable to a numeric value

--- a/common/docker-entrypoint.sh
+++ b/common/docker-entrypoint.sh
@@ -32,11 +32,21 @@ parseBoolean() {
 
 # This line is an addition to the NGINX Docker image's entrypoint script.
 if [ -z ${DNS_RESOLVERS+x} ]; then
-   # This method of pulling individual nameservers from
-   # /etc/resolv.conf taken from the entrypoint script in the
-   # official docker image.
-   # https://github.com/nginxinc/docker-nginx/blob/master/entrypoint/15-local-resolvers.envsh
-  export DNS_RESOLVERS="$(awk 'BEGIN{ORS=" "} $1=="nameserver" {print $2}' /etc/resolv.conf)"
+    resolvers=""
+
+    # This method of pulling individual nameservers from
+    # /etc/resolv.conf taken from the entrypoint script in the
+    # official docker image.
+    # https://github.com/nginxinc/docker-nginx/blob/master/entrypoint/15-local-resolvers.envsh
+    for ip in $(awk 'BEGIN{ORS=" "} $1=="nameserver" {print $2}' /etc/resolv.conf)
+    do
+        if echo "${ip}" | grep -q ':'; then
+          resolvers="$resolvers [${ip}]"
+        else
+          resolvers="$resolvers $ip"
+        fi
+    done
+    export DNS_RESOLVERS="${resolvers}"
 fi
 
 # Normalize the CORS_ENABLED environment variable to a numeric value


### PR DESCRIPTION
# What
Fixes an issue where comments in the `/etc/resolv.conf` would get into the dns resolvers list and cause an error when starting the s3 gateway.

## How
Following a suggestion on the issue, the logic from [this file](https://github.com/nginxinc/docker-nginx/blob/master/entrypoint/15-local-resolvers.envsh) in the official NGINX docker container was ported over to replace the existing logic.

Given a `/etc/resolv.conf` that looks like this:
```
nameserver 127.0.0.11
nameserver 8.8.4.4
nameserver 94.198.184.14
nameserver 94.198.184.34
# NOTE: the libc resolver may not support more than 3 nameservers.
# The nameservers listed below may not be recognized.
nameserver 8.8.8.8
options ndots:0

```

The existing code would produce this:
```
127.0.0.11 8.8.4.4 94.198.184.14 94.198.184.34 [NOTE:] The 8.8.8.8
```

With this change applied it looks like this:
```
127.0.0.11 8.8.4.4 94.198.184.14 94.198.184.34 8.8.8.8
```

The startup printout looks like this with the change applied:
```
Origin: http://bucket-1.minio:9000
Region: us-east-1
Addressing Style: virtual
AWS Signatures Version: v2
DNS Resolvers: 127.0.0.11 8.8.4.4 94.198.184.14 94.198.184.34 8.8.8.8
Directory Listing Enabled: false
Directory Listing Path Prefix:
Provide Index Pages Enabled:
Append slash for directory enabled:
Stripping the following headers from responses: x-amz-;
CORS Enabled: 0
/docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
```


## Notes
Ideally we should be incorporating the entrypoint scripts from the official nginx docker image.  For now we're just porting key logic to get the issue solved quickly.  The integration of these scripts will have some other concerns.  An issue has been filed for this work: https://github.com/nginxinc/nginx-s3-gateway/issues/175