### PR TITLE
Add x-amz-content-sha256 to CanonicalHeaders

### DIFF
--- a/common/etc/nginx/include/awssig4.js
+++ b/common/etc/nginx/include/awssig4.js
@@ -28,7 +28,7 @@ const mod_hmac = require('crypto');
  * Constant defining the headers being signed.
  * @type {string}
  */
-const DEFAULT_SIGNED_HEADERS = 'host;x-amz-date';
+const DEFAULT_SIGNED_HEADERS = 'host;x-amz-content-sha256;x-amz-date';
 
 /**
  * Create HTTP Authorization header for authenticating with an AWS compatible
@@ -76,6 +76,7 @@ function _buildCanonicalRequest(r,
     method, uri, queryParams, host, amzDatetime, sessionToken) {
     const payloadHash = awsHeaderPayloadHash(r);
     let canonicalHeaders = 'host:' + host + '\n' +
+                           'x-amz-content-sha256:' + payloadHash + '\n' +
                            'x-amz-date:' + amzDatetime + '\n';
 
     if (sessionToken && sessionToken.length > 0) {

--- a/test/unit/awssig4_test.js
+++ b/test/unit/awssig4_test.js
@@ -74,7 +74,7 @@ function _runSignatureV4(r) {
     const canonicalRequest = awssig4._buildCanonicalRequest(r, 
         r.method, req.uri, req.queryParams, req.host, amzDatetime, creds.sessionToken);
 
-    var expected = '600721cacc21e3de14416de7517868381831f4709e5c5663bbf2b738e4d5abe4';
+    var expected = 'cf4dd9e1d28c74e2284f938011efc8230d0c20704f56f67e4a3bfc2212026bec';
     var signature = awssig4._buildSignatureV4(r, 
         amzDatetime, eightDigitDate, creds, region, service, canonicalRequest);
     


### PR DESCRIPTION
As writing in [Signature Calculations for the Authorization Header: Transferring Payload in a Single Chunk (AWS Signature Version 4)](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-header-based-auth.html)

> The x-amz-content-sha256 header is required for all AWS Signature Version 4 requests. It provides a hash of the request payload. If there is no payload, you must provide the hash of an empty string.

> For the purpose of calculating an authorization signature, only the host and any x-amz-* headers are required;

We should add x-amz-content-sha256 to CanonicalHeaders