### PR TITLE
Build multi-architecture images

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -172,132 +172,76 @@ jobs:
       - name: Run tests - latest njs version
         run: ./test.sh --latest-njs --type oss
 
+  build-unprivileged-for-test:
+    runs-on: ubuntu-latest
+    needs: test-oss
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: oss
+          path: /tmp
+      - name: Load image
+        run: |
+          docker load --input /tmp/oss.tar
+      - name: Build and load oss image
+        uses: docker/build-push-action@v5
+        with:
+          file: Dockerfile.unprivileged
+          context: .
+          tags: nginx-s3-gateway:unprivileged-oss
+          load: true
+      # Save manually here since we need to use the `docker` buildx `driver` but that can't output
+      # a file that upload-artifact likes.
+      - name: save image
+        run: |
+          docker save nginx-s3-gateway:unprivileged-oss > /tmp/unprivileged.tar
+      - name: Upload artifact - unprivileged
+        uses: actions/upload-artifact@v3
+        with:
+          name: unprivileged
+          path: /tmp/unprivileged.tar
 
-  #     - name: Build and export - unprivileged
-  #       uses: docker/build-push-action@v5
-  #       with:
-  #         file: Dockerfile.unprivileged
-  #         context: .
-  #         tags: localhost:5000/nginx-s3-gateway:unprivileged
-  #         push: false
-  #         outputs: type=oci,dest=/tmp/unprivileged.tar
-  #         platforms: linux/amd64,linux/arm64
-  #         build-contexts: |
-  #           nginx-s3-gateway=docker-image://localhost:5000/nginx-s3-gateway:oss
-  #     - name: Upload artifact - unprivileged
-  #       uses: actions/upload-artifact@v3
-  #       with:
-  #         name: unprivileged
-  #         path: /tmp/unprivileged.tar
-  # test-oss:
-  #   runs-on: ubuntu-latest
-  #   if: github.ref != 'refs/heads/master'
-  #   needs: build
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     ## Start tests.  Keep things here because we can't keep the registry between jobs
-  #     ## TODO: Try saving the artifact after all are built?  What happens to the other archs?
-  #     - name: Install dependencies
-  #       run: sudo apt-get update -qq && sudo apt-get install -y curl wait-for-it
-  #     - name: Restore cached binaries
-  #       id: cache-binaries-restore
-  #       uses: actions/cache/restore@v3
-  #       with:
-  #         path: .bin
-  #         key: ${{ runner.os }}-binaries
-  #     - name: Install MinIO Client
-  #       run: |
-  #         mkdir .bin || exit 0
-  #         cd .bin
-  #         curl --insecure --retry 6 --fail --location --output mc.RELEASE.2023-06-19T19-31-19Z "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z"
-  #         curl --insecure --retry 6 --fail --silent --location "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z.sha256sum" | sha256sum --check -
-  #         mv mc.RELEASE.2023-06-19T19-31-19Z mc
-  #         chmod +x mc
+  test-unprivileged:
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/master'
+    needs: build-unprivileged-for-test
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: sudo apt-get update -qq && sudo apt-get install -y curl wait-for-it
+      - name: Restore cached binaries
+        id: cache-binaries-restore
+        uses: actions/cache/restore@v3
+        with:
+          path: .bin
+          key: ${{ runner.os }}-binaries
+      - name: Install MinIO Client
+        run: |
+          mkdir .bin || exit 0
+          cd .bin
+          curl --insecure --retry 6 --fail --location --output mc.RELEASE.2023-06-19T19-31-19Z "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z"
+          curl --insecure --retry 6 --fail --silent --location "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z.sha256sum" | sha256sum --check -
+          mv mc.RELEASE.2023-06-19T19-31-19Z mc
+          chmod +x mc
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: unprivileged
+          path: /tmp
+      - name: Load image
+        run: |
+          docker load --input /tmp/unprivileged.tar
+          docker tag nginx-s3-gateway:unprivileged-oss nginx-s3-gateway
+      - name: Run tests - unprivileged
+        run: ./test.sh --unprivileged --type oss
 
-  #     ## OSS Test. No retagging needed
-  #     - name: Download artifact
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: oss
-  #         path: /tmp
-  #     - name: Load image
-  #       run: |
-  #         docker load --input /tmp/oss.tar
-  #     - name: Run tests - stable njs version
-  #       run: ./test.sh --type oss
-
-  # test-latest-njs:
-  #   runs-on: ubuntu-latest
-  #   if: github.ref != 'refs/heads/master'
-  #   needs: test-oss
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     ## Start tests.  Keep things here because we can't keep the registry between jobs
-  #     ## TODO: Try saving the artifact after all are built?  What happens to the other archs?
-  #     - name: Install dependencies
-  #       run: sudo apt-get update -qq && sudo apt-get install -y curl wait-for-it
-  #     - name: Restore cached binaries
-  #       id: cache-binaries-restore
-  #       uses: actions/cache/restore@v3
-  #       with:
-  #         path: .bin
-  #         key: ${{ runner.os }}-binaries
-  #     - name: Install MinIO Client
-  #       run: |
-  #         mkdir .bin || exit 0
-  #         cd .bin
-  #         curl --insecure --retry 6 --fail --location --output mc.RELEASE.2023-06-19T19-31-19Z "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z"
-  #         curl --insecure --retry 6 --fail --silent --location "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z.sha256sum" | sha256sum --check -
-  #         mv mc.RELEASE.2023-06-19T19-31-19Z mc
-  #         chmod +x mc
-  #     - name: Download artifact
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: latest-njs
-  #         path: /tmp
-  #     - name: Load image
-  #       run: |
-  #         docker load --input /tmp/latest-njs.tar
-  #         docker tag localhost:5000/nginx-s3-gateway:latest-njs-oss nginx-s3-gateway
-  #     - name: Run tests - latest njs version
-  #       run: ./test.sh --latest-njs --type oss
-
-  # test-unprivileged:
-  #   runs-on: ubuntu-latest
-  #   if: github.ref != 'refs/heads/master'
-  #   needs: test-oss
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     ## Start tests.  Keep things here because we can't keep the registry between jobs
-  #     ## TODO: Try saving the artifact after all are built?  What happens to the other archs?
-  #     - name: Install dependencies
-  #       run: sudo apt-get update -qq && sudo apt-get install -y curl wait-for-it
-  #     - name: Restore cached binaries
-  #       id: cache-binaries-restore
-  #       uses: actions/cache/restore@v3
-  #       with:
-  #         path: .bin
-  #         key: ${{ runner.os }}-binaries
-  #     - name: Install MinIO Client
-  #       run: |
-  #         mkdir .bin || exit 0
-  #         cd .bin
-  #         curl --insecure --retry 6 --fail --location --output mc.RELEASE.2023-06-19T19-31-19Z "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z"
-  #         curl --insecure --retry 6 --fail --silent --location "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z.sha256sum" | sha256sum --check -
-  #         mv mc.RELEASE.2023-06-19T19-31-19Z mc
-  #         chmod +x mc
-  #     - name: Download artifact
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: unprivileged
-  #         path: /tmp
-  #     - name: Load image
-  #       run: |
-  #         docker load --input /tmp/unprivileged.tar
-  #         docker tag localhost:5000/nginx-s3-gateway:unprivileged nginx-s3-gateway
-  #     - name: Run tests - stable njs version - unprivileged process
-  #       run: ./test.sh --unprivileged --type oss
-
+# After the tests are done, build multiarch and push to both github packages and dockerhub if we are on master/main
   # tag-and-push:
   #   runs-on: ubuntu-latest
   #   needs: [test-oss, test-latest-njs, test-unprivileged]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ on:
 
 
 jobs:
-  build-oss:
+  build:
     runs-on: ubuntu-latest
     services:
       registry:
@@ -36,7 +36,11 @@ jobs:
           - 5000:5000
       # Note that uploading the artifact won't work.  We will need to build and push it to a local registry.
       # See here https://docs.docker.com/build/ci/github-actions/named-contexts/#using-with-a-container-builder
-
+      # This person has my problem: https://stackoverflow.com/questions/75831482/how-to-use-a-local-docker-registry2-from-one-job-as-a-container-for-another-job
+      # The issue is that the docker container that is the registery does not persist between jobs.
+      # So I"d need to do something dumb like use the artifact upload and download to get to to the next
+      # step then do it there.
+      # Time to cut my losses and do it mostly in one run.
     if: github.ref != 'refs/heads/master'
     steps:
       - uses: actions/checkout@v4
@@ -47,175 +51,60 @@ jobs:
         with:
           # network=host driver-opt needed to push to local registry
           driver-opts: network=host
-      - name: Build and export
+      - name: Build and export oss image
         uses: docker/build-push-action@v5
         with:
           file: Dockerfile.oss
           context: .
-          tags: nginx-s3-gateway , nginx-s3-gateway:oss
+          tags: localhost:5000/nginx-s3-gateway , localhost:5000/nginx-s3-gateway:oss
           push: true
-
-  test-oss:
-    runs-on: ubuntu-latest
-    needs: build-oss
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
-
-    if: github.ref != 'refs/heads/master'
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install dependencies
-        run: sudo apt-get update -qq && sudo apt-get install -y curl wait-for-it
-      - name: Restore cached binaries
-        id: cache-binaries-restore
-        uses: actions/cache/restore@v3
-        with:
-          path: .bin
-          key: ${{ runner.os }}-binaries
-      - name: Install MinIO Client
+      - name: save image for upload
         run: |
-          mkdir .bin || exit 0
-          cd .bin
-          curl --insecure --retry 6 --fail --location --output mc.RELEASE.2023-06-19T19-31-19Z "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z"
-          curl --insecure --retry 6 --fail --silent --location "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z.sha256sum" | sha256sum --check -
-          mv mc.RELEASE.2023-06-19T19-31-19Z mc
-          chmod +x mc
-      - name: Save cached binaries
-        id: cache-binaries-save
-        uses: actions/cache/save@v3
+          docker save localhost:5000/nginx-s3-gateway > oss.tar
+      - name: Upload artifact - oss
+        uses: actions/upload-artifact@v3
         with:
-          path: .bin
-          key: ${{ steps.cache-binaries-restore.outputs.cache-primary-key }}
-      - name: Load image
-        run: |
-          docker pull localhost:5000/nginx-s3-gateway:oss
-          docker tag nginx-s3-gateway:oss nginx-s3-gateway 
-      - name: Run tests - stable njs version
-        run: ./test.sh --type oss
+          name: oss
+          path: /tmp/oss.tar
 
-  build-latest-njs:
-    runs-on: ubuntu-latest
-    needs: test-oss
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
-
-    if: github.ref != 'refs/heads/master'
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          # network=host driver-opt needed to push to local registry
-          driver-opts: network=host
-      - name: Build and export
+      - name: Build and export latest-njs image
         uses: docker/build-push-action@v5
         with:
           file: Dockerfile.latest-njs
           context: .
-          tags: nginx-s3-gateway:latest-njs-oss
-          push: true
+          tags: localhost:5000/nginx-s3-gateway:latest-njs-oss
+          push: false
+          outputs: type=docker,dest=/tmp/latest-njs.tar
           build-contexts: |
             nginx-s3-gateway=docker-image://localhost:5000/nginx-s3-gateway:oss
-
-  test-latest-njs:
-    runs-on: ubuntu-latest
-    needs: build-latest-njs
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
-
-    if: github.ref != 'refs/heads/master'
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install dependencies
-        run: sudo apt-get update -qq && sudo apt-get install -y curl wait-for-it
-      - name: Restore cached binaries
-        id: cache-binaries-restore
-        uses: actions/cache/restore@v3
+      - name: Upload artifact - latest-njs
+        uses: actions/upload-artifact@v3
         with:
-          path: .bin
-          key: ${{ runner.os }}-binaries
-      - name: Install MinIO Client
-        run: |
-          mkdir .bin || exit 0
-          cd .bin
-          curl --insecure --retry 6 --fail --location --output mc.RELEASE.2023-06-19T19-31-19Z "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z"
-          curl --insecure --retry 6 --fail --silent --location "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z.sha256sum" | sha256sum --check -
-          mv mc.RELEASE.2023-06-19T19-31-19Z mc
-          chmod +x mc
-      - name: Save cached binaries
-        id: cache-binaries-save
-        uses: actions/cache/save@v3
-        with:
-          path: .bin
-          key: ${{ steps.cache-binaries-restore.outputs.cache-primary-key }}
-      - name: Load image
-        run: |
-          docker pull localhost:5000/nginx-s3-gateway:latest-njs-oss
-          docker tag nginx-s3-gateway:latest-njs-oss nginx-s3-gateway         
-      - name: Run tests - latest njs version
-        run: ./test.sh --latest-njs --type oss
+          name: latest-njs
+          path: /tmp/latest-njs.tar
 
-  build-oss-unprivileged:
-    runs-on: ubuntu-latest
-    needs: test-oss
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
-
-    if: github.ref != 'refs/heads/master'
-    steps:
-      - uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-        with:
-          # network=host driver-opt needed to push to local registry
-          driver-opts: network=host
-      - name: Build and export
+      - name: Build and export - unprivileged
         uses: docker/build-push-action@v5
         with:
           file: Dockerfile.unprivileged
           context: .
-          tags: nginx-s3-gateway:unprivileged
-          push: true
+          tags: localhost:5000/nginx-s3-gateway:unprivileged
+          push: false
+          outputs: type=docker,dest=/tmp/unprivileged.tar
           build-contexts: |
             nginx-s3-gateway=docker-image://localhost:5000/nginx-s3-gateway:oss
-
-      # - name: Run tests - latest njs version
-      #   run: ./test.sh --latest-njs --type oss
-      # - name: Run tests - stable njs version
-      #   run: ./test.sh --type oss
-      # - name: Run tests - stable njs version - unprivileged process
-      #   run: ./test.sh --unprivileged --type oss
-      # - name: Run tests - latest njs version - unprivileged process
-      #   run: ./test.sh --latest-njs --unprivileged --type oss
-
-  test-oss-unprivileged:
+      - name: Upload artifact - unprivileged
+        uses: actions/upload-artifact@v3
+        with:
+          name: unprivileged
+          path: /tmp/unprivileged.tar
+  test:
     runs-on: ubuntu-latest
-    needs: build-oss-unprivileged
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
-
     if: github.ref != 'refs/heads/master'
     steps:
       - uses: actions/checkout@v4
+      ## Start tests.  Keep things here because we can't keep the registry between jobs
+      ## TODO: Try saving the artifact after all are built?  What happens to the other archs?
       - name: Install dependencies
         run: sudo apt-get update -qq && sudo apt-get install -y curl wait-for-it
       - name: Restore cached binaries
@@ -232,18 +121,33 @@ jobs:
           curl --insecure --retry 6 --fail --silent --location "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z.sha256sum" | sha256sum --check -
           mv mc.RELEASE.2023-06-19T19-31-19Z mc
           chmod +x mc
-      - name: Save cached binaries
-        id: cache-binaries-save
-        uses: actions/cache/save@v3
+
+      ## OSS Test. No retagging needed
+      - name: Download artifact
+        uses: actions/download-artifact@v3
         with:
-          path: .bin
-          key: ${{ steps.cache-binaries-restore.outputs.cache-primary-key }}
+          name: oss
+          path: /tmp
       - name: Load image
         run: |
-          docker pull localhost:5000/nginx-s3-gateway:unprivileged
-          docker tag nginx-s3-gateway:unprivileged nginx-s3-gateway          
-      - name: Run tests - stable njs version - unprivileged process
-        run: ./test.sh --unprivileged --type oss
+          docker load --input /tmp/oss.tar
+      - name: Run tests - stable njs version
+        run: ./test.sh --type oss
+
+      # ## Latest NJS test. Requires that we retag the latest njs one as the primary for now
+      # - name: Load image latest-oss
+      #   run: |
+      #     docker pull localhost:5000/nginx-s3-gateway:latest-njs-oss
+      #     docker tag nginx-s3-gateway:latest-njs-oss nginx-s3-gateway         
+      # - name: Run tests - latest njs version
+      #   run: ./test.sh --latest-njs --type oss
+
+      # - name: Load image - unprivilegedp
+      #   run: |
+      #     docker pull localhost:5000/nginx-s3-gateway:unprivileged
+      #     docker tag nginx-s3-gateway:unprivileged nginx-s3-gateway          
+      # - name: Run tests - stable njs version - unprivileged process
+      #   run: ./test.sh --unprivileged --type oss
 
   # build_and_deploy:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,27 +4,31 @@ name: CI
 # events but only for the master branch
 on:
   push:
-  # temporarily run on every push for testing
-  #   branches: [ master ]
-  # pull_request:
-    # branches: [ master ]
-
-# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+  temporarily run on every push for testing
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
 
 
+env:
+  CI: true
 
 
- #                                ┌──────────────────┐        ┌────────────────┐      ┌────────────────┐
- # ┌─────────┐     ┌─────────┬────► Build Latest NJS ├────────►Test Latest NJS ├─────►│Push Latest NJS │
- # │Build OSS├────►│Test OSS │    └──────────────────┘        └────────────────┘      └────────────────┘
- # └─────────┘     └──┬──────┤
- #                    │      │    ┌──────────────────┐       ┌──────────────────┐     ┌─────────────────┐
- #                    │      └────►Build Unprivileged├───────►Test Unprivileged ├────►│Push Unprivileged│
- #                    │           └──────────────────┘       └──────────────────┘     ├────────┬────────┘
- #                    │                                                               ├────────┤
- #                    └──────────────────────────────────────────────────────────────►│Push OSS│
- #                                                                                    └────────┘
+# Job progression.  We make sure that the base image [oss] builds and passes tests before kicking off the other builds
 
+    #                                ┌──────────────────┐        ┌────────────────┐      ┌────────────────┐
+    # ┌─────────┐     ┌─────────┬────► Build Latest NJS ├────────►Test Latest NJS ├─────►│Push Latest NJS │
+    # │Build OSS├────►│Test OSS │    └──────────────────┘        └────────────────┘      └────────────────┘
+    # └─────────┘     └──┬──────┤
+    #                    │      │    ┌──────────────────┐       ┌──────────────────┐     ┌─────────────────┐
+    #                    │      └────►Build Unprivileged├───────►Test Unprivileged ├────►│Push Unprivileged│
+    #                    │           └──────────────────┘       └──────────────────┘     ├────────┬────────┘
+    #                    │                                                               ├────────┤
+    #                    └──────────────────────────────────────────────────────────────►│Push OSS│
+    #                                                                                    └────────┘
+
+# As a last step, if we are on the main/master branch, multi-architecture images will be built and pushed to github packages
+# and docker hub
 
 jobs:
   build-oss-for-test:
@@ -45,30 +49,6 @@ jobs:
         with:
           name: oss
           path: /tmp/oss.tar
-
-    # steps:
-    #   - uses: actions/checkout@v4
-    #   #  Build again to export the file locally so we can save all arch versions.
-    #   - name: Build and export oss image
-    #   - name: Set up Docker Buildx
-    #     uses: docker/setup-buildx-action@v3
-    #     with:
-    #       driver: docker
-    #     uses: docker/build-push-action@v5
-    #     with:
-    #       file: Dockerfile.oss
-    #       context: .
-    #       tags: nginx-s3-gateway , nginx-s3-gateway:oss
-    #       load: true
-    #   - name: save image for upload
-    #     run: |
-    #     run: |
-    #       docker save nginx-s3-gateway > oss.tar
-    #   - name: Upload artifact - oss
-    #     uses: actions/upload-artifact@v3
-    #     with:
-    #       name: oss
-    #       path: /tmp/oss.tar
 
   test-oss:
     runs-on: ubuntu-latest
@@ -93,7 +73,6 @@ jobs:
           mv mc.RELEASE.2023-06-19T19-31-19Z mc
           chmod +x mc
 
-      ## OSS Test. No retagging needed
       - name: Download artifact
         uses: actions/download-artifact@v3
         with:
@@ -129,6 +108,8 @@ jobs:
           context: .
           tags: nginx-s3-gateway:latest-njs-oss
           load: true
+      # Save manually here since we need to use the `docker` buildx `driver` but that can't output
+      # a file that upload-artifact likes.
       - name: save image
         run: |
           docker save nginx-s3-gateway:latest-njs-oss > /tmp/latest-njs.tar
@@ -246,9 +227,9 @@ jobs:
     runs-on: ubuntu-latest
     needs: [test-oss, test-latest-njs, test-unprivileged]
 
-    # if: |
-    #   github.ref == 'refs/heads/master' ||
-    #   github.ref == 'refs/heads/main'
+    if: |
+      github.ref == 'refs/heads/master' ||
+      github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
       - name: Get current date
@@ -272,142 +253,44 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push oss image to local registry
+      - name: Build and push image [oss]
         uses: docker/build-push-action@v5
         with:
           file: Dockerfile.oss
           context: .
           push: true
           platforms: linux/amd64,linux/arm64
+          provenance: false
           tags: |
-            ghcr.io/${{ github.repository }}/nginx-oss-s3-gateway:latest-${{ steps.date.outputs.date }}-new-build-test
-            ghcr.io/${{ github.repository }}/nginx-oss-s3-gateway:latest-new-build-test
-      
-  # Dockerhub tags
-  # nginxinc/nginx-s3-gateway:latest-${{ steps.date.outputs.date }}-new-build-test
-  # nginxinc/nginx-s3-gateway:latest-new-build-test
+            ghcr.io/${{ github.repository }}/nginx-oss-s3-gateway:latest-${{ steps.date.outputs.date }}
+            ghcr.io/${{ github.repository }}/nginx-oss-s3-gateway:latest
+            nginxinc/nginx-s3-gateway:latest-${{ steps.date.outputs.date }}
+            nginxinc/nginx-s3-gateway:latest
 
-  #         path: /tmp
-  #     - name: Download artifact - unprivileged
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: unprivileged
-  #         path: /tmp
-      
-  #     - name: Load and retag oss image [oss]
-  #       run: |
-  #         docker load --input /tmp/oss.tar
-  #         docker tag localhost:5000/nginx-s3-gateway docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-${{ steps.date.outputs.date }}-new-build-test
-  #         docker tag localhost:5000/nginx-s3-gateway docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-new-build-test
-  #     - name: Push container image to github [oss date]
-  #       run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-${{ steps.date.outputs.date }}-new-build-test
-  #     - name: Push container image to github [oss latest]
-  #       run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-new-build-test
-  #     - name: Load and retag oss image [latest-njs-oss]
-  #       run: |
-  #         docker load --input /tmp/latest-njs.tar
-  #         docker tag localhost:5000/nginx-s3-gateway::latest-njs-oss docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-njs-oss-${{ steps.date.outputs.date }}-new-build-test
-  #         docker tag localhost:5000/nginx-s3-gateway::latest-njs-oss docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-njs-oss-new-build-test
-  #     - name: Push container image to github [latest-njs-oss date]
-  #       run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-njs-oss-${{ steps.date.outputs.date }}-new-build-test
-  #     - name: Push container image to github [latest-njs-oss]
-  #       run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-njs-oss-new-build-test
-  
+      - name: Build and push image [latest-njs]
+        uses: docker/build-push-action@v5
+        with:
+          file: Dockerfile.latest-njs
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+          tags: |
+            ghcr.io/${{ github.repository }}/nginx-oss-s3-gateway:latest-njs-oss-${{ steps.date.outputs.date }}
+            ghcr.io/${{ github.repository }}/nginx-oss-s3-gateway:latest-njs-oss
+            nginxinc/nginx-s3-gateway:latest-njs-oss-${{ steps.date.outputs.date }}
+            nginxinc/nginx-s3-gateway:latest-njs-oss
 
-  #     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-  #     - uses: actions/checkout@v2
-
-  #     - name: Get current date
-  #       id: date
-  #       run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
-  #     - name: Configure Github Package Registry
-  #       run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u $GITHUB_ACTOR --password-stdin
-
-  #     - name: Install dependencies
-  #       run: sudo apt-get update -qq && sudo apt-get install -y curl wait-for-it
-  #     - name: Restore cached binaries
-  #       id: cache-binaries-restore
-  #       uses: actions/cache/restore@v3
-  #       with:
-  #         path: .bin
-  #         key: ${{ runner.os }}-binaries
-  #     - name: Install MinIO Client
-  #       run: |
-  #         mkdir .bin || exit 0
-  #         cd .bin
-  #         curl --insecure --retry 6 --fail --silent --location --output mc.RELEASE.2023-06-19T19-31-19Z "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z"
-  #         curl --insecure --retry 6 --fail --silent --location "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z.sha256sum" | sha256sum --check -
-  #         mv mc.RELEASE.2023-06-19T19-31-19Z mc
-  #         chmod +x mc
-
-  #     # Run tests and builds image
-  #     - name: Run tests - latest njs version
-  #       run: ./test.sh --latest-njs --type oss
-  #     # latest-njs-oss image push [Github]
-  #     - name: Tag container image for Push to github [latest-njs-oss date]
-  #       run: docker tag nginx-s3-gateway:latest-njs-oss docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-njs-oss-${{ steps.date.outputs.date }}
-  #     - name: Tag container image for Push to github [latest-njs-oss]
-  #       run: docker tag nginx-s3-gateway:latest-njs-oss docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-njs-oss
-  #     - name: Push container image to github [latest-njs-oss date]
-  #       run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-njs-oss-${{ steps.date.outputs.date }}
-  #     - name: Push container image to github [latest-njs-oss]
-  #       run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-njs-oss
-
-  #     # Run tests and builds image
-  #     - name: Run tests - stable njs version - unprivileged process
-  #       run: ./test.sh --unprivileged --type oss
-  #     # unprivileged-oss image push [Github]
-  #     - name: Tag container image for Push to github [unprivileged-oss date]
-  #       run: docker tag nginx-s3-gateway:unprivileged-oss docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:unprivileged-oss-${{ steps.date.outputs.date }}
-  #     - name: Tag container image for Push to github [unprivileged-oss]
-  #       run: docker tag nginx-s3-gateway:unprivileged-oss docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:unprivileged-oss
-  #     - name: Push container image to github [unprivileged-oss date]
-  #       run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:unprivileged-oss-${{ steps.date.outputs.date }}
-  #     - name: Push container image to github [unprivileged-oss]
-  #       run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:unprivileged-oss
-
-  #     # Run tests and builds image
-  #     - name: Run tests - stable njs version
-  #       run: ./test.sh --type oss
-  #     # oss image push [Github]
-  #     - name: Tag container image for Push to github [oss date]
-  #       run: docker tag nginx-s3-gateway:oss docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-${{ steps.date.outputs.date }}
-  #     - name: Tag container image for Push to github [oss]
-  #       run: docker tag nginx-s3-gateway:oss docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest
-  #     - name: Push container image to github [oss date]
-  #       run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-${{ steps.date.outputs.date }}
-  #     - name: Push container image to github [oss latest]
-  #       run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest
-  #     # Login to Docker Hub
-  #     - name: Login to Docker Hub
-  #       uses: docker/login-action@v1
-  #       with:
-  #         username: ${{ secrets.DOCKER_HUB_USERNAME }}
-  #         password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-  #     # latest-njs-oss image push [Docker Hub]
-  #     - name: Tag container image for Push to Docker Hub [latest-njs-oss date]
-  #       run: docker tag nginx-s3-gateway:latest-njs-oss nginxinc/nginx-s3-gateway:latest-njs-oss-${{ steps.date.outputs.date }}
-  #     - name: Tag container image for Push to Docker Hub [latest-njs-oss]
-  #       run: docker tag nginx-s3-gateway:latest-njs-oss nginxinc/nginx-s3-gateway:latest-njs-oss
-  #     - name: Push container image to Docker Hub [latest-njs-oss date]
-  #       run: docker push nginxinc/nginx-s3-gateway:latest-njs-oss-${{ steps.date.outputs.date }}
-  #     - name: Push container image to Docker Hub [latest-njs-oss]
-  #       run: docker push nginxinc/nginx-s3-gateway:latest-njs-oss
-  #     # unprivileged-oss image push [Docker Hub]
-  #     - name: Tag container image for Push to Docker Hub [unprivileged-oss date]
-  #       run: docker tag nginx-s3-gateway:unprivileged-oss nginxinc/nginx-s3-gateway:unprivileged-oss-${{ steps.date.outputs.date }}
-  #     - name: Tag container image for Push to Docker Hub [unprivileged-oss]
-  #       run: docker tag nginx-s3-gateway:unprivileged-oss nginxinc/nginx-s3-gateway:unprivileged-oss
-  #     - name: Push container image to Docker Hub [unprivileged-oss date]
-  #       run: docker push nginxinc/nginx-s3-gateway:unprivileged-oss-${{ steps.date.outputs.date }}
-  #     - name: Push container image to Docker Hub [unprivileged-oss]
-  #       run: docker push nginxinc/nginx-s3-gateway:unprivileged-oss
-  #     # oss image push [Docker Hub]
-  #     - name: Tag container image for Push to Docker Hub [oss date]
-  #       run: docker tag nginx-s3-gateway:oss nginxinc/nginx-s3-gateway:latest-${{ steps.date.outputs.date }}
-  #     - name: Tag container image for Push to Docker Hub [oss]
-  #       run: docker tag nginx-s3-gateway:oss nginxinc/nginx-s3-gateway:latest
-  #     - name: Push container image to Docker Hub [oss date]
-  #       run: docker push nginxinc/nginx-s3-gateway:latest-${{ steps.date.outputs.date }}
-  #     - name: Push container image to Docker Hub [oss latest]
-  #       run: docker push nginxinc/nginx-s3-gateway:latest
+      - name: Build and push image [unprivileged]
+        uses: docker/build-push-action@v5
+        with:
+          file: Dockerfile.unprivileged
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+          tags: |
+            ghcr.io/${{ github.repository }}/nginx-oss-s3-gateway:unprivileged-oss-${{ steps.date.outputs.date }}
+            ghcr.io/${{ github.repository }}/nginx-oss-s3-gateway:unprivileged-oss
+            nginxinc/nginx-s3-gateway:unprivileged-oss-${{ steps.date.outputs.date }}
+            nginxinc/nginx-s3-gateway:unprivileged-oss

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,9 +58,15 @@ jobs:
           context: .
           tags: localhost:5000/nginx-s3-gateway , localhost:5000/nginx-s3-gateway:oss
           push: true
+      # Since the above build pushes to the registry only now we load it locally so we can save it
+      # It's not possible with push and save in one go.
+      - name: Load image oss
+        run: |
+          docker pull localhost:5000/nginx-s3-gateway
+          docker tag localhost:5000/nginx-s3-gateway nginx-s3-gateway  
       - name: save image for upload
         run: |
-          docker save localhost:5000/nginx-s3-gateway > oss.tar
+          docker save nginx-s3-gateway > oss.tar
       - name: Upload artifact - oss
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Build and export
         uses: docker/build-push-action@v5
         with:
-          file Dockerfile.oss
+          file: Dockerfile.oss
           context: .
           tags: nginx-s3-gateway , nginx-s3-gateway:oss
           outputs: type=docker,dest=/tmp/oss.tar
@@ -50,45 +50,45 @@ jobs:
           name: oss
           path: /tmp/oss.tar
 
-    test-oss:
-      runs-on: ubuntu-latest
-      needs: build-oss
+  test-oss:
+    runs-on: ubuntu-latest
+    needs: build-oss
 
-      if: github.ref != 'refs/heads/master'
-      steps:
-        - uses: actions/checkout@v4
-        - name: Install dependencies
-          run: sudo apt-get update -qq && sudo apt-get install -y curl wait-for-it
-        - name: Restore cached binaries
-          id: cache-binaries-restore
-          uses: actions/cache/restore@v3
-          with:
-            path: .bin
-            key: ${{ runner.os }}-binaries
-        - name: Install MinIO Client
-          run: |
-            mkdir .bin || exit 0
-            cd .bin
-            curl --insecure --retry 6 --fail --location --output mc.RELEASE.2023-06-19T19-31-19Z "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z"
-            curl --insecure --retry 6 --fail --silent --location "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z.sha256sum" | sha256sum --check -
-            mv mc.RELEASE.2023-06-19T19-31-19Z mc
-            chmod +x mc
-        - name: Save cached binaries
-          id: cache-binaries-save
-          uses: actions/cache/save@v3
-          with:
-            path: .bin
-            key: ${{ steps.cache-binaries-restore.outputs.cache-primary-key }}
-        - name: Download artifact
-          uses: actions/download-artifact@v3
-          with:
-            name: oss
-            path: /tmp
-        - name: Load image
-          run: |
-            docker load --input /tmp/oss.tar          
-        - name: Run tests - stable njs version
-          run: ./test.sh --type oss
+    if: github.ref != 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: sudo apt-get update -qq && sudo apt-get install -y curl wait-for-it
+      - name: Restore cached binaries
+        id: cache-binaries-restore
+        uses: actions/cache/restore@v3
+        with:
+          path: .bin
+          key: ${{ runner.os }}-binaries
+      - name: Install MinIO Client
+        run: |
+          mkdir .bin || exit 0
+          cd .bin
+          curl --insecure --retry 6 --fail --location --output mc.RELEASE.2023-06-19T19-31-19Z "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z"
+          curl --insecure --retry 6 --fail --silent --location "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z.sha256sum" | sha256sum --check -
+          mv mc.RELEASE.2023-06-19T19-31-19Z mc
+          chmod +x mc
+      - name: Save cached binaries
+        id: cache-binaries-save
+        uses: actions/cache/save@v3
+        with:
+          path: .bin
+          key: ${{ steps.cache-binaries-restore.outputs.cache-primary-key }}
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: oss
+          path: /tmp
+      - name: Load image
+        run: |
+          docker load --input /tmp/oss.tar          
+      - name: Run tests - stable njs version
+        run: ./test.sh --type oss
 
   build-latest-njs:
     runs-on: ubuntu-latest
@@ -102,17 +102,17 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Download the base artifact
-          uses: actions/download-artifact@v3
-          with:
-            name: oss
-            path: /tmp
-        - name: Load image
-          run: |
-            docker load --input /tmp/oss.tar 
+        uses: actions/download-artifact@v3
+        with:
+          name: oss
+          path: /tmp
+      - name: Load image
+        run: |
+          docker load --input /tmp/oss.tar 
       - name: Build and export
         uses: docker/build-push-action@v5
         with:
-          file Dockerfile.latest-njs
+          file: Dockerfile.latest-njs
           context: .
           tags: nginx-s3-gateway , nginx-s3-gateway:latest-njs-oss
           outputs: type=docker,dest=/tmp/latest-njs.tar
@@ -122,45 +122,45 @@ jobs:
           name: latest-njs
           path: /tmp/latest-njs.tar
 
-    test-latest-njs:
-      runs-on: ubuntu-latest
-      needs: build-latest-njs:
+  test-latest-njs:
+    runs-on: ubuntu-latest
+    needs: build-latest-njs
 
-      if: github.ref != 'refs/heads/master'
-      steps:
-        - uses: actions/checkout@v4
-        - name: Install dependencies
-          run: sudo apt-get update -qq && sudo apt-get install -y curl wait-for-it
-        - name: Restore cached binaries
-          id: cache-binaries-restore
-          uses: actions/cache/restore@v3
-          with:
-            path: .bin
-            key: ${{ runner.os }}-binaries
-        - name: Install MinIO Client
-          run: |
-            mkdir .bin || exit 0
-            cd .bin
-            curl --insecure --retry 6 --fail --location --output mc.RELEASE.2023-06-19T19-31-19Z "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z"
-            curl --insecure --retry 6 --fail --silent --location "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z.sha256sum" | sha256sum --check -
-            mv mc.RELEASE.2023-06-19T19-31-19Z mc
-            chmod +x mc
-        - name: Save cached binaries
-          id: cache-binaries-save
-          uses: actions/cache/save@v3
-          with:
-            path: .bin
-            key: ${{ steps.cache-binaries-restore.outputs.cache-primary-key }}
-        - name: Download artifact
-          uses: actions/download-artifact@v3
-          with:
-            name: latest-njs
-            path: /tmp
-        - name: Load image
-          run: |
-            docker load --input /tmp/latest-njs.tar          
-        - name: name: Run tests - latest njs version
-          run: ./test.sh --type oss
+    if: github.ref != 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: sudo apt-get update -qq && sudo apt-get install -y curl wait-for-it
+      - name: Restore cached binaries
+        id: cache-binaries-restore
+        uses: actions/cache/restore@v3
+        with:
+          path: .bin
+          key: ${{ runner.os }}-binaries
+      - name: Install MinIO Client
+        run: |
+          mkdir .bin || exit 0
+          cd .bin
+          curl --insecure --retry 6 --fail --location --output mc.RELEASE.2023-06-19T19-31-19Z "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z"
+          curl --insecure --retry 6 --fail --silent --location "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z.sha256sum" | sha256sum --check -
+          mv mc.RELEASE.2023-06-19T19-31-19Z mc
+          chmod +x mc
+      - name: Save cached binaries
+        id: cache-binaries-save
+        uses: actions/cache/save@v3
+        with:
+          path: .bin
+          key: ${{ steps.cache-binaries-restore.outputs.cache-primary-key }}
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: latest-njs
+          path: /tmp
+      - name: Load image
+        run: |
+          docker load --input /tmp/latest-njs.tar          
+      - name: Run tests - latest njs version
+        run: ./test.sh --type oss
 
 
   build-oss-unprivileged:
@@ -175,17 +175,17 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: Download the base artifact
-          uses: actions/download-artifact@v3
-          with:
-            name: oss
-            path: /tmp
-        - name: Load image
-          run: |
-            docker load --input /tmp/oss.tar 
+        uses: actions/download-artifact@v3
+        with:
+          name: oss
+          path: /tmp
+      - name: Load image
+        run: |
+          docker load --input /tmp/oss.tar 
       - name: Build and export
         uses: docker/build-push-action@v5
         with:
-          file Dockerfile.unprivileged
+          file: Dockerfile.unprivileged
           context: .
           tags: nginx-s3-gateway , nginx-s3-gateway:unprivileged
           outputs: type=docker,dest=/tmp/unprivileged.tar

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,7 +4,6 @@ name: CI
 # events but only for the master branch
 on:
   push:
-  temporarily run on every push for testing
     branches: [ master ]
   pull_request:
     branches: [ master ]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,7 +51,6 @@ jobs:
 
   test-oss:
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/master'
     needs: build-oss-for-test
     steps:
       - uses: actions/checkout@v4
@@ -120,7 +119,6 @@ jobs:
 
   test-latest-njs:
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/master'
     needs: build-latest-njs-for-test
     steps:
       - uses: actions/checkout@v4
@@ -189,7 +187,6 @@ jobs:
 
   test-unprivileged:
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/master'
     needs: build-unprivileged-for-test
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ env:
 
 jobs:
   build-oss-for-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
@@ -47,10 +47,12 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: oss
-          path: /tmp/oss.tar
+          path: $TMPDIR/oss.tar
+          retention-days: 1
+          if-no-files-found: error
 
   test-oss:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: build-oss-for-test
     steps:
       - uses: actions/checkout@v4
@@ -83,7 +85,7 @@ jobs:
         run: ./test.sh --type oss
 
   build-latest-njs-for-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: test-oss
     steps:
       - uses: actions/checkout@v4
@@ -116,9 +118,11 @@ jobs:
         with:
           name: latest-njs
           path: /tmp/latest-njs.tar
+          retention-days: 1
+          if-no-files-found: error
 
   test-latest-njs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: build-latest-njs-for-test
     steps:
       - uses: actions/checkout@v4
@@ -151,7 +155,7 @@ jobs:
         run: ./test.sh --latest-njs --type oss
 
   build-unprivileged-for-test:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: test-oss
     steps:
       - uses: actions/checkout@v4
@@ -184,9 +188,11 @@ jobs:
         with:
           name: unprivileged
           path: /tmp/unprivileged.tar
+          retention-days: 1
+          if-no-files-found: error
 
   test-unprivileged:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: build-unprivileged-for-test
     steps:
       - uses: actions/checkout@v4
@@ -220,7 +226,7 @@ jobs:
 
 # After the tests are done, build multiarch and push to both github packages and dockerhub if we are on master/main
   tag-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [test-oss, test-latest-njs, test-unprivileged]
 
     if: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,7 +104,7 @@ jobs:
         with:
           name: unprivileged
           path: /tmp/unprivileged.tar
-  test:
+  test-oss:
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/master'
     needs: build
@@ -141,20 +141,77 @@ jobs:
       - name: Run tests - stable njs version
         run: ./test.sh --type oss
 
-      # ## Latest NJS test. Requires that we retag the latest njs one as the primary for now
-      # - name: Load image latest-oss
-      #   run: |
-      #     docker pull localhost:5000/nginx-s3-gateway:latest-njs-oss
-      #     docker tag nginx-s3-gateway:latest-njs-oss nginx-s3-gateway         
-      # - name: Run tests - latest njs version
-      #   run: ./test.sh --latest-njs --type oss
+  test-latest-njs:
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/master'
+    needs: test-oss
+    steps:
+      - uses: actions/checkout@v4
+      ## Start tests.  Keep things here because we can't keep the registry between jobs
+      ## TODO: Try saving the artifact after all are built?  What happens to the other archs?
+      - name: Install dependencies
+        run: sudo apt-get update -qq && sudo apt-get install -y curl wait-for-it
+      - name: Restore cached binaries
+        id: cache-binaries-restore
+        uses: actions/cache/restore@v3
+        with:
+          path: .bin
+          key: ${{ runner.os }}-binaries
+      - name: Install MinIO Client
+        run: |
+          mkdir .bin || exit 0
+          cd .bin
+          curl --insecure --retry 6 --fail --location --output mc.RELEASE.2023-06-19T19-31-19Z "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z"
+          curl --insecure --retry 6 --fail --silent --location "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z.sha256sum" | sha256sum --check -
+          mv mc.RELEASE.2023-06-19T19-31-19Z mc
+          chmod +x mc
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: latest-njs
+          path: /tmp
+      - name: Load image
+        run: |
+          docker load --input /tmp/latest-njs.tar
+          docker tag nginx-s3-gateway:latest-njs-oss nginx-s3-gateway
+      - name: Run tests - latest njs version
+        run: ./test.sh --latest-njs --type oss
 
-      # - name: Load image - unprivilegedp
-      #   run: |
-      #     docker pull localhost:5000/nginx-s3-gateway:unprivileged
-      #     docker tag nginx-s3-gateway:unprivileged nginx-s3-gateway          
-      # - name: Run tests - stable njs version - unprivileged process
-      #   run: ./test.sh --unprivileged --type oss
+  test-unprivileged:
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/master'
+    needs: test-oss
+    steps:
+      - uses: actions/checkout@v4
+      ## Start tests.  Keep things here because we can't keep the registry between jobs
+      ## TODO: Try saving the artifact after all are built?  What happens to the other archs?
+      - name: Install dependencies
+        run: sudo apt-get update -qq && sudo apt-get install -y curl wait-for-it
+      - name: Restore cached binaries
+        id: cache-binaries-restore
+        uses: actions/cache/restore@v3
+        with:
+          path: .bin
+          key: ${{ runner.os }}-binaries
+      - name: Install MinIO Client
+        run: |
+          mkdir .bin || exit 0
+          cd .bin
+          curl --insecure --retry 6 --fail --location --output mc.RELEASE.2023-06-19T19-31-19Z "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z"
+          curl --insecure --retry 6 --fail --silent --location "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z.sha256sum" | sha256sum --check -
+          mv mc.RELEASE.2023-06-19T19-31-19Z mc
+          chmod +x mc
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: unprivileged
+          path: /tmp
+      - name: Load image
+        run: |
+          docker load --input /tmp/unprivileged.tar
+          docker tag nginx-s3-gateway:unprivileged nginx-s3-gateway
+      - name: Run tests - stable njs version - unprivileged process
+        run: ./test.sh --unprivileged --type oss
 
   # build_and_deploy:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,7 +42,7 @@ jobs:
           file: Dockerfile.oss
           context: .
           tags: nginx-s3-gateway , nginx-s3-gateway:oss
-          outputs: type=docker,dest=/tmp/oss.tar
+          outputs: type=docker,dest=${{ runner.temp }}/oss.tar
       - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
@@ -80,7 +80,7 @@ jobs:
           path: ${{ runner.temp }}
       - name: Load image
         run: |
-          docker load --input /tmp/oss.tar
+          docker load --input ${{ runner.temp }}/oss.tar
       - name: Run tests - stable njs version
         run: ./test.sh --type oss
 
@@ -100,7 +100,7 @@ jobs:
           path: ${{ runner.temp }}
       - name: Load image
         run: |
-          docker load --input /tmp/oss.tar
+          docker load --input ${{ runner.temp }}/oss.tar
       - name: Build and load oss image
         uses: docker/build-push-action@v5
         with:
@@ -112,7 +112,7 @@ jobs:
       # a file that upload-artifact likes.
       - name: save image
         run: |
-          docker save nginx-s3-gateway:latest-njs-oss > /tmp/latest-njs.tar
+          docker save nginx-s3-gateway:latest-njs-oss > ${{ runner.temp }}/latest-njs.tar
       - name: Upload artifact - latest-njs
         uses: actions/upload-artifact@v3
         with:
@@ -149,7 +149,7 @@ jobs:
           path: ${{ runner.temp }}
       - name: Load image
         run: |
-          docker load --input /tmp/latest-njs.tar
+          docker load --input ${{ runner.temp }}/latest-njs.tar
           docker tag nginx-s3-gateway:latest-njs-oss nginx-s3-gateway
       - name: Run tests - latest njs version
         run: ./test.sh --latest-njs --type oss
@@ -170,7 +170,7 @@ jobs:
           path: ${{ runner.temp }}
       - name: Load image
         run: |
-          docker load --input /tmp/oss.tar
+          docker load --input ${{ runner.temp }}/oss.tar
       - name: Build and load oss image
         uses: docker/build-push-action@v5
         with:
@@ -182,7 +182,7 @@ jobs:
       # a file that upload-artifact likes.
       - name: save image
         run: |
-          docker save nginx-s3-gateway:unprivileged-oss > /tmp/unprivileged.tar
+          docker save nginx-s3-gateway:unprivileged-oss > ${{ runner.temp }}/unprivileged.tar
       - name: Upload artifact - unprivileged
         uses: actions/upload-artifact@v3
         with:
@@ -219,7 +219,7 @@ jobs:
           path: ${{ runner.temp }}
       - name: Load image
         run: |
-          docker load --input /tmp/unprivileged.tar
+          docker load --input ${{ runner.temp }}/unprivileged.tar
           docker tag nginx-s3-gateway:unprivileged-oss nginx-s3-gateway
       - name: Run tests - unprivileged
         run: ./test.sh --unprivileged --type oss

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -280,8 +280,8 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ghcr.io/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-${{ steps.date.outputs.date }}-new-build-test
-            ghcr.io/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-new-build-test
+            ghcr.io/${{ GITHUB_REPOSITORY }}/nginx-oss-s3-gateway:latest-${{ steps.date.outputs.date }}-new-build-test
+            ghcr.io/${{ GITHUB_REPOSITORY }}/nginx-oss-s3-gateway:latest-new-build-test
       
   # Dockerhub tags
   # nginxinc/nginx-s3-gateway:latest-${{ steps.date.outputs.date }}-new-build-test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,6 +29,13 @@ on:
 jobs:
   build-oss:
     runs-on: ubuntu-latest
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+      # Note that uploading the artifact won't work.  We will need to build and push it to a local registry.
+      # See here https://docs.docker.com/build/ci/github-actions/named-contexts/#using-with-a-container-builder
 
     if: github.ref != 'refs/heads/master'
     steps:
@@ -37,22 +44,25 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          # network=host driver-opt needed to push to local registry
+          driver-opts: network=host
       - name: Build and export
         uses: docker/build-push-action@v5
         with:
           file: Dockerfile.oss
           context: .
           tags: nginx-s3-gateway , nginx-s3-gateway:oss
-          outputs: type=docker,dest=/tmp/oss.tar
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: oss
-          path: /tmp/oss.tar
+          push: true
 
   test-oss:
     runs-on: ubuntu-latest
     needs: build-oss
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
 
     if: github.ref != 'refs/heads/master'
     steps:
@@ -79,20 +89,21 @@ jobs:
         with:
           path: .bin
           key: ${{ steps.cache-binaries-restore.outputs.cache-primary-key }}
-      - name: Download artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: oss
-          path: /tmp
       - name: Load image
         run: |
-          docker load --input /tmp/oss.tar          
+          docker pull localhost:5000/nginx-s3-gateway:oss
+          docker tag nginx-s3-gateway:oss nginx-s3-gateway 
       - name: Run tests - stable njs version
         run: ./test.sh --type oss
 
   build-latest-njs:
     runs-on: ubuntu-latest
     needs: test-oss
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
 
     if: github.ref != 'refs/heads/master'
     steps:
@@ -101,33 +112,27 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Download the base artifact
-        uses: actions/download-artifact@v3
         with:
-          name: oss
-          path: /tmp
-      - name: Load image
-        run: |
-          docker load --input /tmp/oss.tar
-          echo "Images:"
-          docker image ls -a
-          echo "--------"
+          # network=host driver-opt needed to push to local registry
+          driver-opts: network=host
       - name: Build and export
         uses: docker/build-push-action@v5
         with:
           file: Dockerfile.latest-njs
           context: .
-          tags: nginx-s3-gateway , nginx-s3-gateway:latest-njs-oss
-          outputs: type=docker,dest=/tmp/latest-njs.tar
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: latest-njs
-          path: /tmp/latest-njs.tar
+          tags: nginx-s3-gateway:latest-njs-oss
+          push: true
+          build-contexts: |
+            nginx-s3-gateway=docker-image://localhost:5000/nginx-s3-gateway:oss
 
   test-latest-njs:
     runs-on: ubuntu-latest
     needs: build-latest-njs
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
 
     if: github.ref != 'refs/heads/master'
     steps:
@@ -154,21 +159,21 @@ jobs:
         with:
           path: .bin
           key: ${{ steps.cache-binaries-restore.outputs.cache-primary-key }}
-      - name: Download artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: latest-njs
-          path: /tmp
       - name: Load image
         run: |
-          docker load --input /tmp/latest-njs.tar          
+          docker pull localhost:5000/nginx-s3-gateway:latest-njs-oss
+          docker tag nginx-s3-gateway:latest-njs-oss nginx-s3-gateway         
       - name: Run tests - latest njs version
-        run: ./test.sh --type oss
-
+        run: ./test.sh --latest-njs --type oss
 
   build-oss-unprivileged:
     runs-on: ubuntu-latest
     needs: test-oss
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
 
     if: github.ref != 'refs/heads/master'
     steps:
@@ -177,42 +182,36 @@ jobs:
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Download the base artifact
-        uses: actions/download-artifact@v3
         with:
-          name: oss
-          path: /tmp
-      - name: Load image
-        run: |
-          docker load --input /tmp/oss.tar
-          echo "Images:"
-          docker image ls -a
-          echo "--------"
+          # network=host driver-opt needed to push to local registry
+          driver-opts: network=host
       - name: Build and export
         uses: docker/build-push-action@v5
         with:
           file: Dockerfile.unprivileged
           context: .
-          tags: nginx-s3-gateway , nginx-s3-gateway:unprivileged
-          outputs: type=docker,dest=/tmp/unprivileged.tar
-      - name: Upload artifact
-        uses: actions/upload-artifact@v3
-        with:
-          name: unprivileged
-          path: /tmp/unprivileged.tar
+          tags: nginx-s3-gateway:unprivileged
+          push: true
+          build-contexts: |
+            nginx-s3-gateway=docker-image://localhost:5000/nginx-s3-gateway:oss
 
-      - name: Run tests - latest njs version
-        run: ./test.sh --latest-njs --type oss
-      - name: Run tests - stable njs version
-        run: ./test.sh --type oss
-      - name: Run tests - stable njs version - unprivileged process
-        run: ./test.sh --unprivileged --type oss
-      - name: Run tests - latest njs version - unprivileged process
-        run: ./test.sh --latest-njs --unprivileged --type oss
+      # - name: Run tests - latest njs version
+      #   run: ./test.sh --latest-njs --type oss
+      # - name: Run tests - stable njs version
+      #   run: ./test.sh --type oss
+      # - name: Run tests - stable njs version - unprivileged process
+      #   run: ./test.sh --unprivileged --type oss
+      # - name: Run tests - latest njs version - unprivileged process
+      #   run: ./test.sh --latest-njs --unprivileged --type oss
 
   test-oss-unprivileged:
     runs-on: ubuntu-latest
     needs: build-oss-unprivileged
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
 
     if: github.ref != 'refs/heads/master'
     steps:
@@ -239,16 +238,12 @@ jobs:
         with:
           path: .bin
           key: ${{ steps.cache-binaries-restore.outputs.cache-primary-key }}
-      - name: Download artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: unprivileged
-          path: /tmp
       - name: Load image
         run: |
-          docker load --input /tmp/unprivileged.tar          
+          docker pull localhost:5000/nginx-s3-gateway:unprivileged
+          docker tag nginx-s3-gateway:unprivileged nginx-s3-gateway          
       - name: Run tests - stable njs version - unprivileged process
-        run: ./test.sh --type oss
+        run: ./test.sh --unprivileged --type oss
 
   # build_and_deploy:
   #   runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -242,29 +242,47 @@ jobs:
         run: ./test.sh --unprivileged --type oss
 
 # After the tests are done, build multiarch and push to both github packages and dockerhub if we are on master/main
-  # tag-and-push:
-  #   runs-on: ubuntu-latest
-  #   needs: [test-oss, test-latest-njs, test-unprivileged]
+  tag-and-push:
+    runs-on: ubuntu-latest
+    needs: [test-oss, test-latest-njs, test-unprivileged]
 
-  #   if: |
-  #     github.ref == 'refs/heads/master' ||
-  #     github.ref == 'refs/heads/main'
-  #   steps:
-  #     - name: Get current date
-  #       id: date
-  #       run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
-  #     - name: Configure Github Package Registry
-  #       run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u $GITHUB_ACTOR --password-stdin
+    # if: |
+    #   github.ref == 'refs/heads/master' ||
+    #   github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push oss image to local registry
+        uses: docker/build-push-action@v5
+        with:
+          file: Dockerfile.oss
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: |
+            # nginxinc/nginx-s3-gateway:latest-${{ steps.date.outputs.date }}-new-build-test
+            # nginxinc/nginx-s3-gateway:latest-new-build-test
+            ghcr.io/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-${{ steps.date.outputs.date }}-new-build-test
+            ghcr.io/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-new-build-test
       
-  #     - name: Download artifact - oss
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: oss
-  #         path: /tmp
-  #     - name: Download artifact - latest-njs
-  #       uses: actions/download-artifact@v3
-  #       with:
-  #         name: latest-njs
+
   #         path: /tmp
   #     - name: Download artifact - unprivileged
   #       uses: actions/download-artifact@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: oss
-          path: $TMPDIR/oss.tar
+          path: /tmp/oss.tar
           retention-days: 1
           if-no-files-found: error
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,7 +66,7 @@ jobs:
           docker tag localhost:5000/nginx-s3-gateway nginx-s3-gateway  
       - name: save image for upload
         run: |
-          docker save nginx-s3-gateway > oss.tar
+          docker save nginx-s3-gateway > /tmp/oss.tar
       - name: Upload artifact - oss
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,7 @@ jobs:
         with:
           # network=host driver-opt needed to push to local registry
           driver-opts: network=host
+          platforms: linux/amd64,linux/arm64
       - name: Build and export oss image
         uses: docker/build-push-action@v5
         with:
@@ -58,6 +59,7 @@ jobs:
           context: .
           tags: localhost:5000/nginx-s3-gateway , localhost:5000/nginx-s3-gateway:oss
           push: true
+          platforms: linux/amd64,linux/arm64
       # Since the above build pushes to the registry only now we load it locally so we can save it
       # It's not possible with push and save in one go.
       - name: Load image oss
@@ -81,6 +83,7 @@ jobs:
           tags: localhost:5000/nginx-s3-gateway:latest-njs-oss
           push: false
           outputs: type=docker,dest=/tmp/latest-njs.tar
+          platforms: linux/amd64,linux/arm64
           build-contexts: |
             nginx-s3-gateway=docker-image://localhost:5000/nginx-s3-gateway:oss
       - name: Upload artifact - latest-njs
@@ -97,6 +100,7 @@ jobs:
           tags: localhost:5000/nginx-s3-gateway:unprivileged
           push: false
           outputs: type=docker,dest=/tmp/unprivileged.tar
+          platforms: linux/amd64,linux/arm64
           build-contexts: |
             nginx-s3-gateway=docker-image://localhost:5000/nginx-s3-gateway:oss
       - name: Upload artifact - unprivileged
@@ -213,11 +217,56 @@ jobs:
       - name: Run tests - stable njs version - unprivileged process
         run: ./test.sh --unprivileged --type oss
 
-  # build_and_deploy:
-  #   runs-on: ubuntu-latest
+  tag-and-push:
+    runs-on: ubuntu-latest
+    needs: [test-oss, test-latest-njs, test-unprivileged]
 
-  #   if: github.ref == 'refs/heads/master'
-  #   steps:
+    if: |
+      github.ref == 'refs/heads/master' ||
+      github.ref == 'refs/heads/main'
+    steps:
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
+      - name: Configure Github Package Registry
+        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u $GITHUB_ACTOR --password-stdin
+      
+      - name: Download artifact - oss
+        uses: actions/download-artifact@v3
+        with:
+          name: oss
+          path: /tmp
+      - name: Download artifact - latest-njs
+        uses: actions/download-artifact@v3
+        with:
+          name: latest-njs
+          path: /tmp
+      - name: Download artifact - unprivileged
+        uses: actions/download-artifact@v3
+        with:
+          name: unprivileged
+          path: /tmp
+      
+      - name: Load and retag oss image [oss]
+        run: |
+          docker load --input /tmp/oss.tar
+          docker tag localhost:5000/nginx-s3-gateway docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-${{ steps.date.outputs.date }}-new-build-test
+          docker tag localhost:5000/nginx-s3-gateway docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-new-build-test
+      - name: Push container image to github [oss date]
+        run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-${{ steps.date.outputs.date }}-new-build-test
+      - name: Push container image to github [oss latest]
+        run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-new-build-test
+      - name: Load and retag oss image [latest-njs-oss]
+        run: |
+          docker load --input /tmp/latest-njs.tar
+          docker tag localhost:5000/nginx-s3-gateway::latest-njs-oss docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-njs-oss-${{ steps.date.outputs.date }}-new-build-test
+          docker tag localhost:5000/nginx-s3-gateway::latest-njs-oss docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-njs-oss-new-build-test
+      - name: Push container image to github [latest-njs-oss date]
+        run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-njs-oss-${{ steps.date.outputs.date }}-new-build-test
+      - name: Push container image to github [latest-njs-oss]
+        run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-njs-oss-new-build-test
+  
+
   #     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
   #     - uses: actions/checkout@v2
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -108,7 +108,10 @@ jobs:
           path: /tmp
       - name: Load image
         run: |
-          docker load --input /tmp/oss.tar 
+          docker load --input /tmp/oss.tar
+          echo "Images:"
+          docker image ls -a
+          echo "--------"
       - name: Build and export
         uses: docker/build-push-action@v5
         with:
@@ -182,7 +185,9 @@ jobs:
       - name: Load image
         run: |
           docker load --input /tmp/oss.tar
+          echo "Images:"
           docker image ls -a
+          echo "--------"
       - name: Build and export
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: oss
-          path: /tmp/oss.tar
+          path: ${{ runner.temp }}/oss.tar
           retention-days: 1
           if-no-files-found: error
 
@@ -77,7 +77,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: oss
-          path: /tmp
+          path: ${{ runner.temp }}
       - name: Load image
         run: |
           docker load --input /tmp/oss.tar
@@ -97,7 +97,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: oss
-          path: /tmp
+          path: ${{ runner.temp }}
       - name: Load image
         run: |
           docker load --input /tmp/oss.tar
@@ -117,7 +117,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: latest-njs
-          path: /tmp/latest-njs.tar
+          path: ${{ runner.temp }}/latest-njs.tar
           retention-days: 1
           if-no-files-found: error
 
@@ -146,7 +146,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: latest-njs
-          path: /tmp
+          path: ${{ runner.temp }}
       - name: Load image
         run: |
           docker load --input /tmp/latest-njs.tar
@@ -167,7 +167,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: oss
-          path: /tmp
+          path: ${{ runner.temp }}
       - name: Load image
         run: |
           docker load --input /tmp/oss.tar
@@ -187,7 +187,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: unprivileged
-          path: /tmp/unprivileged.tar
+          path: ${{ runner.temp }}/unprivileged.tar
           retention-days: 1
           if-no-files-found: error
 
@@ -216,7 +216,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: unprivileged
-          path: /tmp
+          path: ${{ runner.temp }}
       - name: Load image
         run: |
           docker load --input /tmp/unprivileged.tar

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,6 +107,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/master'
+    needs: build
     steps:
       - uses: actions/checkout@v4
       ## Start tests.  Keep things here because we can't keep the registry between jobs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -277,11 +277,12 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            # nginxinc/nginx-s3-gateway:latest-${{ steps.date.outputs.date }}-new-build-test
-            # nginxinc/nginx-s3-gateway:latest-new-build-test
             ghcr.io/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-${{ steps.date.outputs.date }}-new-build-test
             ghcr.io/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-new-build-test
       
+  # Dockerhub tags
+  # nginxinc/nginx-s3-gateway:latest-${{ steps.date.outputs.date }}-new-build-test
+  # nginxinc/nginx-s3-gateway:latest-new-build-test
 
   #         path: /tmp
   #     - name: Download artifact - unprivileged

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -280,8 +280,8 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: |
-            ghcr.io/${{ GITHUB_REPOSITORY }}/nginx-oss-s3-gateway:latest-${{ steps.date.outputs.date }}-new-build-test
-            ghcr.io/${{ GITHUB_REPOSITORY }}/nginx-oss-s3-gateway:latest-new-build-test
+            ghcr.io/${{ github.repository }}/nginx-oss-s3-gateway:latest-${{ steps.date.outputs.date }}-new-build-test
+            ghcr.io/${{ github.repository }}/nginx-oss-s3-gateway:latest-new-build-test
       
   # Dockerhub tags
   # nginxinc/nginx-s3-gateway:latest-${{ steps.date.outputs.date }}-new-build-test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,98 +27,55 @@ on:
 
 
 jobs:
-  build:
+  build-oss-for-test:
     runs-on: ubuntu-latest
-    services:
-      registry:
-        image: registry:2
-        ports:
-          - 5000:5000
-      # Note that uploading the artifact won't work.  We will need to build and push it to a local registry.
-      # See here https://docs.docker.com/build/ci/github-actions/named-contexts/#using-with-a-container-builder
-      # This person has my problem: https://stackoverflow.com/questions/75831482/how-to-use-a-local-docker-registry2-from-one-job-as-a-container-for-another-job
-      # The issue is that the docker container that is the registery does not persist between jobs.
-      # So I"d need to do something dumb like use the artifact upload and download to get to to the next
-      # step then do it there.
-      # Time to cut my losses and do it mostly in one run.
-    if: github.ref != 'refs/heads/master'
     steps:
       - uses: actions/checkout@v4
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-        with:
-          # network=host driver-opt needed to push to local registry
-          driver-opts: network=host
-          platforms: linux/amd64,linux/arm64
-      # Since we can't push and save at the same time we push to the local registry so that
-      # other builds can have access to the image (loading it does not work with buildx)
-      - name: Build and push oss image to local registry
+      - name: Build and export
         uses: docker/build-push-action@v5
         with:
           file: Dockerfile.oss
           context: .
-          tags: localhost:5000/nginx-s3-gateway , localhost:5000/nginx-s3-gateway:oss
-          push: true
-          platforms: linux/amd64,linux/arm64
-      #  Build again to export the file locally so we can save all arch versions.
-      - name: Build and export oss image
-        uses: docker/build-push-action@v5
-        with:
-          file: Dockerfile.oss
-          context: .
-          tags: localhost:5000/nginx-s3-gateway , localhost:5000/nginx-s3-gateway:oss
-          push: false
-          outputs: type=oci,dest=/tmp/oss.tar
-          platforms: linux/amd64,linux/arm64
-      - name: Upload artifact - oss
+          tags: nginx-s3-gateway , nginx-s3-gateway:oss
+          outputs: type=docker,dest=/tmp/oss.tar
+      - name: Upload artifact
         uses: actions/upload-artifact@v3
         with:
           name: oss
           path: /tmp/oss.tar
 
-      - name: Build and export latest-njs image
-        uses: docker/build-push-action@v5
-        with:
-          file: Dockerfile.latest-njs
-          context: .
-          tags: localhost:5000/nginx-s3-gateway:latest-njs-oss
-          push: false
-          outputs: type=oci,dest=/tmp/latest-njs.tar
-          platforms: linux/amd64,linux/arm64
-          build-contexts: |
-            nginx-s3-gateway=docker-image://localhost:5000/nginx-s3-gateway:oss
-      - name: Upload artifact - latest-njs
-        uses: actions/upload-artifact@v3
-        with:
-          name: latest-njs
-          path: /tmp/latest-njs.tar
+    # steps:
+    #   - uses: actions/checkout@v4
+    #   #  Build again to export the file locally so we can save all arch versions.
+    #   - name: Build and export oss image
+    #   - name: Set up Docker Buildx
+    #     uses: docker/setup-buildx-action@v3
+    #     with:
+    #       driver: docker
+    #     uses: docker/build-push-action@v5
+    #     with:
+    #       file: Dockerfile.oss
+    #       context: .
+    #       tags: nginx-s3-gateway , nginx-s3-gateway:oss
+    #       load: true
+    #   - name: save image for upload
+    #     run: |
+    #     run: |
+    #       docker save nginx-s3-gateway > oss.tar
+    #   - name: Upload artifact - oss
+    #     uses: actions/upload-artifact@v3
+    #     with:
+    #       name: oss
+    #       path: /tmp/oss.tar
 
-      - name: Build and export - unprivileged
-        uses: docker/build-push-action@v5
-        with:
-          file: Dockerfile.unprivileged
-          context: .
-          tags: localhost:5000/nginx-s3-gateway:unprivileged
-          push: false
-          outputs: type=oci,dest=/tmp/unprivileged.tar
-          platforms: linux/amd64,linux/arm64
-          build-contexts: |
-            nginx-s3-gateway=docker-image://localhost:5000/nginx-s3-gateway:oss
-      - name: Upload artifact - unprivileged
-        uses: actions/upload-artifact@v3
-        with:
-          name: unprivileged
-          path: /tmp/unprivileged.tar
   test-oss:
     runs-on: ubuntu-latest
     if: github.ref != 'refs/heads/master'
-    needs: build
+    needs: build-oss-for-test
     steps:
       - uses: actions/checkout@v4
-      ## Start tests.  Keep things here because we can't keep the registry between jobs
-      ## TODO: Try saving the artifact after all are built?  What happens to the other archs?
       - name: Install dependencies
         run: sudo apt-get update -qq && sudo apt-get install -y curl wait-for-it
       - name: Restore cached binaries
@@ -148,126 +105,247 @@ jobs:
       - name: Run tests - stable njs version
         run: ./test.sh --type oss
 
-  test-latest-njs:
+  build-latest-njs-for-test:
     runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/master'
     needs: test-oss
     steps:
       - uses: actions/checkout@v4
-      ## Start tests.  Keep things here because we can't keep the registry between jobs
-      ## TODO: Try saving the artifact after all are built?  What happens to the other archs?
-      - name: Install dependencies
-        run: sudo apt-get update -qq && sudo apt-get install -y curl wait-for-it
-      - name: Restore cached binaries
-        id: cache-binaries-restore
-        uses: actions/cache/restore@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
         with:
-          path: .bin
-          key: ${{ runner.os }}-binaries
-      - name: Install MinIO Client
-        run: |
-          mkdir .bin || exit 0
-          cd .bin
-          curl --insecure --retry 6 --fail --location --output mc.RELEASE.2023-06-19T19-31-19Z "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z"
-          curl --insecure --retry 6 --fail --silent --location "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z.sha256sum" | sha256sum --check -
-          mv mc.RELEASE.2023-06-19T19-31-19Z mc
-          chmod +x mc
+          driver: docker
       - name: Download artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: latest-njs
-          path: /tmp
-      - name: Load image
-        run: |
-          docker load --input /tmp/latest-njs.tar
-          docker tag localhost:5000/nginx-s3-gateway:latest-njs-oss nginx-s3-gateway
-      - name: Run tests - latest njs version
-        run: ./test.sh --latest-njs --type oss
-
-  test-unprivileged:
-    runs-on: ubuntu-latest
-    if: github.ref != 'refs/heads/master'
-    needs: test-oss
-    steps:
-      - uses: actions/checkout@v4
-      ## Start tests.  Keep things here because we can't keep the registry between jobs
-      ## TODO: Try saving the artifact after all are built?  What happens to the other archs?
-      - name: Install dependencies
-        run: sudo apt-get update -qq && sudo apt-get install -y curl wait-for-it
-      - name: Restore cached binaries
-        id: cache-binaries-restore
-        uses: actions/cache/restore@v3
-        with:
-          path: .bin
-          key: ${{ runner.os }}-binaries
-      - name: Install MinIO Client
-        run: |
-          mkdir .bin || exit 0
-          cd .bin
-          curl --insecure --retry 6 --fail --location --output mc.RELEASE.2023-06-19T19-31-19Z "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z"
-          curl --insecure --retry 6 --fail --silent --location "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z.sha256sum" | sha256sum --check -
-          mv mc.RELEASE.2023-06-19T19-31-19Z mc
-          chmod +x mc
-      - name: Download artifact
-        uses: actions/download-artifact@v3
-        with:
-          name: unprivileged
-          path: /tmp
-      - name: Load image
-        run: |
-          docker load --input /tmp/unprivileged.tar
-          docker tag localhost:5000/nginx-s3-gateway:unprivileged nginx-s3-gateway
-      - name: Run tests - stable njs version - unprivileged process
-        run: ./test.sh --unprivileged --type oss
-
-  tag-and-push:
-    runs-on: ubuntu-latest
-    needs: [test-oss, test-latest-njs, test-unprivileged]
-
-    if: |
-      github.ref == 'refs/heads/master' ||
-      github.ref == 'refs/heads/main'
-    steps:
-      - name: Get current date
-        id: date
-        run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
-      - name: Configure Github Package Registry
-        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u $GITHUB_ACTOR --password-stdin
-      
-      - name: Download artifact - oss
         uses: actions/download-artifact@v3
         with:
           name: oss
           path: /tmp
-      - name: Download artifact - latest-njs
+      - name: Load image
+        run: |
+          docker load --input /tmp/oss.tar
+      - name: Build and load oss image
+        uses: docker/build-push-action@v5
+        with:
+          file: Dockerfile.latest-njs
+          context: .
+          tags: nginx-s3-gateway:latest-njs-oss
+          load: true
+      - name: save image
+        run: |
+          docker save nginx-s3-gateway:latest-njs-oss > /tmp/latest-njs.tar
+      - name: Upload artifact - latest-njs
+        uses: actions/upload-artifact@v3
+        with:
+          name: latest-njs
+          path: /tmp/latest-njs.tar
+
+  test-latest-njs:
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/master'
+    needs: build-latest-njs-for-test
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: sudo apt-get update -qq && sudo apt-get install -y curl wait-for-it
+      - name: Restore cached binaries
+        id: cache-binaries-restore
+        uses: actions/cache/restore@v3
+        with:
+          path: .bin
+          key: ${{ runner.os }}-binaries
+      - name: Install MinIO Client
+        run: |
+          mkdir .bin || exit 0
+          cd .bin
+          curl --insecure --retry 6 --fail --location --output mc.RELEASE.2023-06-19T19-31-19Z "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z"
+          curl --insecure --retry 6 --fail --silent --location "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z.sha256sum" | sha256sum --check -
+          mv mc.RELEASE.2023-06-19T19-31-19Z mc
+          chmod +x mc
+      - name: Download artifact
         uses: actions/download-artifact@v3
         with:
           name: latest-njs
           path: /tmp
-      - name: Download artifact - unprivileged
-        uses: actions/download-artifact@v3
-        with:
-          name: unprivileged
-          path: /tmp
-      
-      - name: Load and retag oss image [oss]
-        run: |
-          docker load --input /tmp/oss.tar
-          docker tag localhost:5000/nginx-s3-gateway docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-${{ steps.date.outputs.date }}-new-build-test
-          docker tag localhost:5000/nginx-s3-gateway docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-new-build-test
-      - name: Push container image to github [oss date]
-        run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-${{ steps.date.outputs.date }}-new-build-test
-      - name: Push container image to github [oss latest]
-        run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-new-build-test
-      - name: Load and retag oss image [latest-njs-oss]
+      - name: Load image
         run: |
           docker load --input /tmp/latest-njs.tar
-          docker tag localhost:5000/nginx-s3-gateway::latest-njs-oss docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-njs-oss-${{ steps.date.outputs.date }}-new-build-test
-          docker tag localhost:5000/nginx-s3-gateway::latest-njs-oss docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-njs-oss-new-build-test
-      - name: Push container image to github [latest-njs-oss date]
-        run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-njs-oss-${{ steps.date.outputs.date }}-new-build-test
-      - name: Push container image to github [latest-njs-oss]
-        run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-njs-oss-new-build-test
+          docker tag nginx-s3-gateway:latest-njs-oss nginx-s3-gateway
+      - name: Run tests - latest njs version
+        run: ./test.sh --latest-njs --type oss
+
+
+  #     - name: Build and export - unprivileged
+  #       uses: docker/build-push-action@v5
+  #       with:
+  #         file: Dockerfile.unprivileged
+  #         context: .
+  #         tags: localhost:5000/nginx-s3-gateway:unprivileged
+  #         push: false
+  #         outputs: type=oci,dest=/tmp/unprivileged.tar
+  #         platforms: linux/amd64,linux/arm64
+  #         build-contexts: |
+  #           nginx-s3-gateway=docker-image://localhost:5000/nginx-s3-gateway:oss
+  #     - name: Upload artifact - unprivileged
+  #       uses: actions/upload-artifact@v3
+  #       with:
+  #         name: unprivileged
+  #         path: /tmp/unprivileged.tar
+  # test-oss:
+  #   runs-on: ubuntu-latest
+  #   if: github.ref != 'refs/heads/master'
+  #   needs: build
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     ## Start tests.  Keep things here because we can't keep the registry between jobs
+  #     ## TODO: Try saving the artifact after all are built?  What happens to the other archs?
+  #     - name: Install dependencies
+  #       run: sudo apt-get update -qq && sudo apt-get install -y curl wait-for-it
+  #     - name: Restore cached binaries
+  #       id: cache-binaries-restore
+  #       uses: actions/cache/restore@v3
+  #       with:
+  #         path: .bin
+  #         key: ${{ runner.os }}-binaries
+  #     - name: Install MinIO Client
+  #       run: |
+  #         mkdir .bin || exit 0
+  #         cd .bin
+  #         curl --insecure --retry 6 --fail --location --output mc.RELEASE.2023-06-19T19-31-19Z "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z"
+  #         curl --insecure --retry 6 --fail --silent --location "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z.sha256sum" | sha256sum --check -
+  #         mv mc.RELEASE.2023-06-19T19-31-19Z mc
+  #         chmod +x mc
+
+  #     ## OSS Test. No retagging needed
+  #     - name: Download artifact
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: oss
+  #         path: /tmp
+  #     - name: Load image
+  #       run: |
+  #         docker load --input /tmp/oss.tar
+  #     - name: Run tests - stable njs version
+  #       run: ./test.sh --type oss
+
+  # test-latest-njs:
+  #   runs-on: ubuntu-latest
+  #   if: github.ref != 'refs/heads/master'
+  #   needs: test-oss
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     ## Start tests.  Keep things here because we can't keep the registry between jobs
+  #     ## TODO: Try saving the artifact after all are built?  What happens to the other archs?
+  #     - name: Install dependencies
+  #       run: sudo apt-get update -qq && sudo apt-get install -y curl wait-for-it
+  #     - name: Restore cached binaries
+  #       id: cache-binaries-restore
+  #       uses: actions/cache/restore@v3
+  #       with:
+  #         path: .bin
+  #         key: ${{ runner.os }}-binaries
+  #     - name: Install MinIO Client
+  #       run: |
+  #         mkdir .bin || exit 0
+  #         cd .bin
+  #         curl --insecure --retry 6 --fail --location --output mc.RELEASE.2023-06-19T19-31-19Z "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z"
+  #         curl --insecure --retry 6 --fail --silent --location "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z.sha256sum" | sha256sum --check -
+  #         mv mc.RELEASE.2023-06-19T19-31-19Z mc
+  #         chmod +x mc
+  #     - name: Download artifact
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: latest-njs
+  #         path: /tmp
+  #     - name: Load image
+  #       run: |
+  #         docker load --input /tmp/latest-njs.tar
+  #         docker tag localhost:5000/nginx-s3-gateway:latest-njs-oss nginx-s3-gateway
+  #     - name: Run tests - latest njs version
+  #       run: ./test.sh --latest-njs --type oss
+
+  # test-unprivileged:
+  #   runs-on: ubuntu-latest
+  #   if: github.ref != 'refs/heads/master'
+  #   needs: test-oss
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #     ## Start tests.  Keep things here because we can't keep the registry between jobs
+  #     ## TODO: Try saving the artifact after all are built?  What happens to the other archs?
+  #     - name: Install dependencies
+  #       run: sudo apt-get update -qq && sudo apt-get install -y curl wait-for-it
+  #     - name: Restore cached binaries
+  #       id: cache-binaries-restore
+  #       uses: actions/cache/restore@v3
+  #       with:
+  #         path: .bin
+  #         key: ${{ runner.os }}-binaries
+  #     - name: Install MinIO Client
+  #       run: |
+  #         mkdir .bin || exit 0
+  #         cd .bin
+  #         curl --insecure --retry 6 --fail --location --output mc.RELEASE.2023-06-19T19-31-19Z "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z"
+  #         curl --insecure --retry 6 --fail --silent --location "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z.sha256sum" | sha256sum --check -
+  #         mv mc.RELEASE.2023-06-19T19-31-19Z mc
+  #         chmod +x mc
+  #     - name: Download artifact
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: unprivileged
+  #         path: /tmp
+  #     - name: Load image
+  #       run: |
+  #         docker load --input /tmp/unprivileged.tar
+  #         docker tag localhost:5000/nginx-s3-gateway:unprivileged nginx-s3-gateway
+  #     - name: Run tests - stable njs version - unprivileged process
+  #       run: ./test.sh --unprivileged --type oss
+
+  # tag-and-push:
+  #   runs-on: ubuntu-latest
+  #   needs: [test-oss, test-latest-njs, test-unprivileged]
+
+  #   if: |
+  #     github.ref == 'refs/heads/master' ||
+  #     github.ref == 'refs/heads/main'
+  #   steps:
+  #     - name: Get current date
+  #       id: date
+  #       run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
+  #     - name: Configure Github Package Registry
+  #       run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u $GITHUB_ACTOR --password-stdin
+      
+  #     - name: Download artifact - oss
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: oss
+  #         path: /tmp
+  #     - name: Download artifact - latest-njs
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: latest-njs
+  #         path: /tmp
+  #     - name: Download artifact - unprivileged
+  #       uses: actions/download-artifact@v3
+  #       with:
+  #         name: unprivileged
+  #         path: /tmp
+      
+  #     - name: Load and retag oss image [oss]
+  #       run: |
+  #         docker load --input /tmp/oss.tar
+  #         docker tag localhost:5000/nginx-s3-gateway docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-${{ steps.date.outputs.date }}-new-build-test
+  #         docker tag localhost:5000/nginx-s3-gateway docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-new-build-test
+  #     - name: Push container image to github [oss date]
+  #       run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-${{ steps.date.outputs.date }}-new-build-test
+  #     - name: Push container image to github [oss latest]
+  #       run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-new-build-test
+  #     - name: Load and retag oss image [latest-njs-oss]
+  #       run: |
+  #         docker load --input /tmp/latest-njs.tar
+  #         docker tag localhost:5000/nginx-s3-gateway::latest-njs-oss docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-njs-oss-${{ steps.date.outputs.date }}-new-build-test
+  #         docker tag localhost:5000/nginx-s3-gateway::latest-njs-oss docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-njs-oss-new-build-test
+  #     - name: Push container image to github [latest-njs-oss date]
+  #       run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-njs-oss-${{ steps.date.outputs.date }}-new-build-test
+  #     - name: Push container image to github [latest-njs-oss]
+  #       run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-njs-oss-new-build-test
   
 
   #     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -181,7 +181,8 @@ jobs:
           path: /tmp
       - name: Load image
         run: |
-          docker load --input /tmp/oss.tar 
+          docker load --input /tmp/oss.tar
+          docker image ls -a
       - name: Build and export
         uses: docker/build-push-action@v5
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -251,6 +251,9 @@ jobs:
     #   github.ref == 'refs/heads/main'
     steps:
       - uses: actions/checkout@v4
+      - name: Get current date
+        id: date
+        run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -173,7 +173,7 @@ jobs:
       - name: Load image
         run: |
           docker load --input /tmp/latest-njs.tar
-          docker tag nginx-s3-gateway:latest-njs-oss nginx-s3-gateway
+          docker tag localhost:5000/nginx-s3-gateway:latest-njs-oss nginx-s3-gateway
       - name: Run tests - latest njs version
         run: ./test.sh --latest-njs --type oss
 
@@ -209,7 +209,7 @@ jobs:
       - name: Load image
         run: |
           docker load --input /tmp/unprivileged.tar
-          docker tag nginx-s3-gateway:unprivileged nginx-s3-gateway
+          docker tag localhost:5000/nginx-s3-gateway:unprivileged nginx-s3-gateway
       - name: Run tests - stable njs version - unprivileged process
         run: ./test.sh --unprivileged --type oss
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -52,7 +52,9 @@ jobs:
           # network=host driver-opt needed to push to local registry
           driver-opts: network=host
           platforms: linux/amd64,linux/arm64
-      - name: Build and export oss image
+      # Since we can't push and save at the same time we push to the local registry so that
+      # other builds can have access to the image (loading it does not work with buildx)
+      - name: Build and push oss image to local registry
         uses: docker/build-push-action@v5
         with:
           file: Dockerfile.oss
@@ -60,15 +62,16 @@ jobs:
           tags: localhost:5000/nginx-s3-gateway , localhost:5000/nginx-s3-gateway:oss
           push: true
           platforms: linux/amd64,linux/arm64
-      # Since the above build pushes to the registry only now we load it locally so we can save it
-      # It's not possible with push and save in one go.
-      - name: Load image oss
-        run: |
-          docker pull localhost:5000/nginx-s3-gateway
-          docker tag localhost:5000/nginx-s3-gateway nginx-s3-gateway  
-      - name: save image for upload
-        run: |
-          docker save nginx-s3-gateway > /tmp/oss.tar
+      #  Build again to export the file locally so we can save all arch versions.
+      - name: Build and export oss image
+        uses: docker/build-push-action@v5
+        with:
+          file: Dockerfile.oss
+          context: .
+          tags: localhost:5000/nginx-s3-gateway , localhost:5000/nginx-s3-gateway:oss
+          push: false
+          outputs: type=oci,dest=/tmp/oss.tar
+          platforms: linux/amd64,linux/arm64
       - name: Upload artifact - oss
         uses: actions/upload-artifact@v3
         with:
@@ -82,7 +85,7 @@ jobs:
           context: .
           tags: localhost:5000/nginx-s3-gateway:latest-njs-oss
           push: false
-          outputs: type=docker,dest=/tmp/latest-njs.tar
+          outputs: type=oci,dest=/tmp/latest-njs.tar
           platforms: linux/amd64,linux/arm64
           build-contexts: |
             nginx-s3-gateway=docker-image://localhost:5000/nginx-s3-gateway:oss
@@ -99,7 +102,7 @@ jobs:
           context: .
           tags: localhost:5000/nginx-s3-gateway:unprivileged
           push: false
-          outputs: type=docker,dest=/tmp/unprivileged.tar
+          outputs: type=oci,dest=/tmp/unprivileged.tar
           platforms: linux/amd64,linux/arm64
           build-contexts: |
             nginx-s3-gateway=docker-image://localhost:5000/nginx-s3-gateway:oss

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,20 +4,213 @@ name: CI
 # events but only for the master branch
 on:
   push:
-    branches: [ master ]
-  pull_request:
-    branches: [ master ]
+  # temporarily run on every push for testing
+  #   branches: [ master ]
+  # pull_request:
+    # branches: [ master ]
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
+
+
+
+
+ #                                ┌──────────────────┐        ┌────────────────┐      ┌────────────────┐
+ # ┌─────────┐     ┌─────────┬────► Build Latest NJS ├────────►Test Latest NJS ├─────►│Push Latest NJS │
+ # │Build OSS├────►│Test OSS │    └──────────────────┘        └────────────────┘      └────────────────┘
+ # └─────────┘     └──┬──────┤
+ #                    │      │    ┌──────────────────┐       ┌──────────────────┐     ┌─────────────────┐
+ #                    │      └────►Build Unprivileged├───────►Test Unprivileged ├────►│Push Unprivileged│
+ #                    │           └──────────────────┘       └──────────────────┘     ├────────┬────────┘
+ #                    │                                                               ├────────┤
+ #                    └──────────────────────────────────────────────────────────────►│Push OSS│
+ #                                                                                    └────────┘
+
+
 jobs:
-  build:
+  build-oss:
     runs-on: ubuntu-latest
 
     if: github.ref != 'refs/heads/master'
     steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and export
+        uses: docker/build-push-action@v5
+        with:
+          file Dockerfile.oss
+          context: .
+          tags: nginx-s3-gateway , nginx-s3-gateway:oss
+          outputs: type=docker,dest=/tmp/oss.tar
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: oss
+          path: /tmp/oss.tar
 
+    test-oss:
+      runs-on: ubuntu-latest
+      needs: build-oss
+
+      if: github.ref != 'refs/heads/master'
+      steps:
+        - uses: actions/checkout@v4
+        - name: Install dependencies
+          run: sudo apt-get update -qq && sudo apt-get install -y curl wait-for-it
+        - name: Restore cached binaries
+          id: cache-binaries-restore
+          uses: actions/cache/restore@v3
+          with:
+            path: .bin
+            key: ${{ runner.os }}-binaries
+        - name: Install MinIO Client
+          run: |
+            mkdir .bin || exit 0
+            cd .bin
+            curl --insecure --retry 6 --fail --location --output mc.RELEASE.2023-06-19T19-31-19Z "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z"
+            curl --insecure --retry 6 --fail --silent --location "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z.sha256sum" | sha256sum --check -
+            mv mc.RELEASE.2023-06-19T19-31-19Z mc
+            chmod +x mc
+        - name: Save cached binaries
+          id: cache-binaries-save
+          uses: actions/cache/save@v3
+          with:
+            path: .bin
+            key: ${{ steps.cache-binaries-restore.outputs.cache-primary-key }}
+        - name: Download artifact
+          uses: actions/download-artifact@v3
+          with:
+            name: oss
+            path: /tmp
+        - name: Load image
+          run: |
+            docker load --input /tmp/oss.tar          
+        - name: Run tests - stable njs version
+          run: ./test.sh --type oss
+
+  build-latest-njs:
+    runs-on: ubuntu-latest
+    needs: test-oss
+
+    if: github.ref != 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Download the base artifact
+          uses: actions/download-artifact@v3
+          with:
+            name: oss
+            path: /tmp
+        - name: Load image
+          run: |
+            docker load --input /tmp/oss.tar 
+      - name: Build and export
+        uses: docker/build-push-action@v5
+        with:
+          file Dockerfile.latest-njs
+          context: .
+          tags: nginx-s3-gateway , nginx-s3-gateway:latest-njs-oss
+          outputs: type=docker,dest=/tmp/latest-njs.tar
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: latest-njs
+          path: /tmp/latest-njs.tar
+
+    test-latest-njs:
+      runs-on: ubuntu-latest
+      needs: build-latest-njs:
+
+      if: github.ref != 'refs/heads/master'
+      steps:
+        - uses: actions/checkout@v4
+        - name: Install dependencies
+          run: sudo apt-get update -qq && sudo apt-get install -y curl wait-for-it
+        - name: Restore cached binaries
+          id: cache-binaries-restore
+          uses: actions/cache/restore@v3
+          with:
+            path: .bin
+            key: ${{ runner.os }}-binaries
+        - name: Install MinIO Client
+          run: |
+            mkdir .bin || exit 0
+            cd .bin
+            curl --insecure --retry 6 --fail --location --output mc.RELEASE.2023-06-19T19-31-19Z "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z"
+            curl --insecure --retry 6 --fail --silent --location "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z.sha256sum" | sha256sum --check -
+            mv mc.RELEASE.2023-06-19T19-31-19Z mc
+            chmod +x mc
+        - name: Save cached binaries
+          id: cache-binaries-save
+          uses: actions/cache/save@v3
+          with:
+            path: .bin
+            key: ${{ steps.cache-binaries-restore.outputs.cache-primary-key }}
+        - name: Download artifact
+          uses: actions/download-artifact@v3
+          with:
+            name: latest-njs
+            path: /tmp
+        - name: Load image
+          run: |
+            docker load --input /tmp/latest-njs.tar          
+        - name: name: Run tests - latest njs version
+          run: ./test.sh --type oss
+
+
+  build-oss-unprivileged:
+    runs-on: ubuntu-latest
+    needs: test-oss
+
+    if: github.ref != 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Download the base artifact
+          uses: actions/download-artifact@v3
+          with:
+            name: oss
+            path: /tmp
+        - name: Load image
+          run: |
+            docker load --input /tmp/oss.tar 
+      - name: Build and export
+        uses: docker/build-push-action@v5
+        with:
+          file Dockerfile.unprivileged
+          context: .
+          tags: nginx-s3-gateway , nginx-s3-gateway:unprivileged
+          outputs: type=docker,dest=/tmp/unprivileged.tar
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: unprivileged
+          path: /tmp/unprivileged.tar
+
+      - name: Run tests - latest njs version
+        run: ./test.sh --latest-njs --type oss
+      - name: Run tests - stable njs version
+        run: ./test.sh --type oss
+      - name: Run tests - stable njs version - unprivileged process
+        run: ./test.sh --unprivileged --type oss
+      - name: Run tests - latest njs version - unprivileged process
+        run: ./test.sh --latest-njs --unprivileged --type oss
+
+  test-oss-unprivileged:
+    runs-on: ubuntu-latest
+    needs: build-oss-unprivileged
+
+    if: github.ref != 'refs/heads/master'
+    steps:
+      - uses: actions/checkout@v4
       - name: Install dependencies
         run: sudo apt-get update -qq && sudo apt-get install -y curl wait-for-it
       - name: Restore cached binaries
@@ -40,114 +233,116 @@ jobs:
         with:
           path: .bin
           key: ${{ steps.cache-binaries-restore.outputs.cache-primary-key }}
-      - name: Run tests - latest njs version
-        run: ./test.sh --latest-njs --type oss
-      - name: Run tests - stable njs version
-        run: ./test.sh --type oss
-      - name: Run tests - stable njs version - unprivileged process
-        run: ./test.sh --unprivileged --type oss
-      - name: Run tests - latest njs version - unprivileged process
-        run: ./test.sh --latest-njs --unprivileged --type oss
-
-  build_and_deploy:
-    runs-on: ubuntu-latest
-
-    if: github.ref == 'refs/heads/master'
-    steps:
-      # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
-      - uses: actions/checkout@v2
-
-      - name: Get current date
-        id: date
-        run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
-      - name: Configure Github Package Registry
-        run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u $GITHUB_ACTOR --password-stdin
-
-      - name: Install dependencies
-        run: sudo apt-get update -qq && sudo apt-get install -y curl wait-for-it
-      - name: Restore cached binaries
-        id: cache-binaries-restore
-        uses: actions/cache/restore@v3
+      - name: Download artifact
+        uses: actions/download-artifact@v3
         with:
-          path: .bin
-          key: ${{ runner.os }}-binaries
-      - name: Install MinIO Client
+          name: unprivileged
+          path: /tmp
+      - name: Load image
         run: |
-          mkdir .bin || exit 0
-          cd .bin
-          curl --insecure --retry 6 --fail --silent --location --output mc.RELEASE.2023-06-19T19-31-19Z "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z"
-          curl --insecure --retry 6 --fail --silent --location "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z.sha256sum" | sha256sum --check -
-          mv mc.RELEASE.2023-06-19T19-31-19Z mc
-          chmod +x mc
-
-      # Run tests and builds image
-      - name: Run tests - latest njs version
-        run: ./test.sh --latest-njs --type oss
-      # latest-njs-oss image push [Github]
-      - name: Tag container image for Push to github [latest-njs-oss date]
-        run: docker tag nginx-s3-gateway:latest-njs-oss docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-njs-oss-${{ steps.date.outputs.date }}
-      - name: Tag container image for Push to github [latest-njs-oss]
-        run: docker tag nginx-s3-gateway:latest-njs-oss docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-njs-oss
-      - name: Push container image to github [latest-njs-oss date]
-        run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-njs-oss-${{ steps.date.outputs.date }}
-      - name: Push container image to github [latest-njs-oss]
-        run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-njs-oss
-
-      # Run tests and builds image
+          docker load --input /tmp/unprivileged.tar          
       - name: Run tests - stable njs version - unprivileged process
-        run: ./test.sh --unprivileged --type oss
-      # unprivileged-oss image push [Github]
-      - name: Tag container image for Push to github [unprivileged-oss date]
-        run: docker tag nginx-s3-gateway:unprivileged-oss docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:unprivileged-oss-${{ steps.date.outputs.date }}
-      - name: Tag container image for Push to github [unprivileged-oss]
-        run: docker tag nginx-s3-gateway:unprivileged-oss docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:unprivileged-oss
-      - name: Push container image to github [unprivileged-oss date]
-        run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:unprivileged-oss-${{ steps.date.outputs.date }}
-      - name: Push container image to github [unprivileged-oss]
-        run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:unprivileged-oss
-
-      # Run tests and builds image
-      - name: Run tests - stable njs version
         run: ./test.sh --type oss
-      # oss image push [Github]
-      - name: Tag container image for Push to github [oss date]
-        run: docker tag nginx-s3-gateway:oss docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-${{ steps.date.outputs.date }}
-      - name: Tag container image for Push to github [oss]
-        run: docker tag nginx-s3-gateway:oss docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest
-      - name: Push container image to github [oss date]
-        run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-${{ steps.date.outputs.date }}
-      - name: Push container image to github [oss latest]
-        run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest
-      # Login to Docker Hub
-      - name: Login to Docker Hub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-      # latest-njs-oss image push [Docker Hub]
-      - name: Tag container image for Push to Docker Hub [latest-njs-oss date]
-        run: docker tag nginx-s3-gateway:latest-njs-oss nginxinc/nginx-s3-gateway:latest-njs-oss-${{ steps.date.outputs.date }}
-      - name: Tag container image for Push to Docker Hub [latest-njs-oss]
-        run: docker tag nginx-s3-gateway:latest-njs-oss nginxinc/nginx-s3-gateway:latest-njs-oss
-      - name: Push container image to Docker Hub [latest-njs-oss date]
-        run: docker push nginxinc/nginx-s3-gateway:latest-njs-oss-${{ steps.date.outputs.date }}
-      - name: Push container image to Docker Hub [latest-njs-oss]
-        run: docker push nginxinc/nginx-s3-gateway:latest-njs-oss
-      # unprivileged-oss image push [Docker Hub]
-      - name: Tag container image for Push to Docker Hub [unprivileged-oss date]
-        run: docker tag nginx-s3-gateway:unprivileged-oss nginxinc/nginx-s3-gateway:unprivileged-oss-${{ steps.date.outputs.date }}
-      - name: Tag container image for Push to Docker Hub [unprivileged-oss]
-        run: docker tag nginx-s3-gateway:unprivileged-oss nginxinc/nginx-s3-gateway:unprivileged-oss
-      - name: Push container image to Docker Hub [unprivileged-oss date]
-        run: docker push nginxinc/nginx-s3-gateway:unprivileged-oss-${{ steps.date.outputs.date }}
-      - name: Push container image to Docker Hub [unprivileged-oss]
-        run: docker push nginxinc/nginx-s3-gateway:unprivileged-oss
-      # oss image push [Docker Hub]
-      - name: Tag container image for Push to Docker Hub [oss date]
-        run: docker tag nginx-s3-gateway:oss nginxinc/nginx-s3-gateway:latest-${{ steps.date.outputs.date }}
-      - name: Tag container image for Push to Docker Hub [oss]
-        run: docker tag nginx-s3-gateway:oss nginxinc/nginx-s3-gateway:latest
-      - name: Push container image to Docker Hub [oss date]
-        run: docker push nginxinc/nginx-s3-gateway:latest-${{ steps.date.outputs.date }}
-      - name: Push container image to Docker Hub [oss latest]
-        run: docker push nginxinc/nginx-s3-gateway:latest
+
+  # build_and_deploy:
+  #   runs-on: ubuntu-latest
+
+  #   if: github.ref == 'refs/heads/master'
+  #   steps:
+  #     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
+  #     - uses: actions/checkout@v2
+
+  #     - name: Get current date
+  #       id: date
+  #       run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
+  #     - name: Configure Github Package Registry
+  #       run: echo ${{ secrets.GITHUB_TOKEN }} | docker login docker.pkg.github.com -u $GITHUB_ACTOR --password-stdin
+
+  #     - name: Install dependencies
+  #       run: sudo apt-get update -qq && sudo apt-get install -y curl wait-for-it
+  #     - name: Restore cached binaries
+  #       id: cache-binaries-restore
+  #       uses: actions/cache/restore@v3
+  #       with:
+  #         path: .bin
+  #         key: ${{ runner.os }}-binaries
+  #     - name: Install MinIO Client
+  #       run: |
+  #         mkdir .bin || exit 0
+  #         cd .bin
+  #         curl --insecure --retry 6 --fail --silent --location --output mc.RELEASE.2023-06-19T19-31-19Z "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z"
+  #         curl --insecure --retry 6 --fail --silent --location "https://dl.min.io/client/mc/release/linux-$(dpkg --print-architecture)/archive/mc.RELEASE.2023-06-19T19-31-19Z.sha256sum" | sha256sum --check -
+  #         mv mc.RELEASE.2023-06-19T19-31-19Z mc
+  #         chmod +x mc
+
+  #     # Run tests and builds image
+  #     - name: Run tests - latest njs version
+  #       run: ./test.sh --latest-njs --type oss
+  #     # latest-njs-oss image push [Github]
+  #     - name: Tag container image for Push to github [latest-njs-oss date]
+  #       run: docker tag nginx-s3-gateway:latest-njs-oss docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-njs-oss-${{ steps.date.outputs.date }}
+  #     - name: Tag container image for Push to github [latest-njs-oss]
+  #       run: docker tag nginx-s3-gateway:latest-njs-oss docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-njs-oss
+  #     - name: Push container image to github [latest-njs-oss date]
+  #       run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-njs-oss-${{ steps.date.outputs.date }}
+  #     - name: Push container image to github [latest-njs-oss]
+  #       run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-njs-oss
+
+  #     # Run tests and builds image
+  #     - name: Run tests - stable njs version - unprivileged process
+  #       run: ./test.sh --unprivileged --type oss
+  #     # unprivileged-oss image push [Github]
+  #     - name: Tag container image for Push to github [unprivileged-oss date]
+  #       run: docker tag nginx-s3-gateway:unprivileged-oss docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:unprivileged-oss-${{ steps.date.outputs.date }}
+  #     - name: Tag container image for Push to github [unprivileged-oss]
+  #       run: docker tag nginx-s3-gateway:unprivileged-oss docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:unprivileged-oss
+  #     - name: Push container image to github [unprivileged-oss date]
+  #       run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:unprivileged-oss-${{ steps.date.outputs.date }}
+  #     - name: Push container image to github [unprivileged-oss]
+  #       run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:unprivileged-oss
+
+  #     # Run tests and builds image
+  #     - name: Run tests - stable njs version
+  #       run: ./test.sh --type oss
+  #     # oss image push [Github]
+  #     - name: Tag container image for Push to github [oss date]
+  #       run: docker tag nginx-s3-gateway:oss docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-${{ steps.date.outputs.date }}
+  #     - name: Tag container image for Push to github [oss]
+  #       run: docker tag nginx-s3-gateway:oss docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest
+  #     - name: Push container image to github [oss date]
+  #       run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest-${{ steps.date.outputs.date }}
+  #     - name: Push container image to github [oss latest]
+  #       run: docker push docker.pkg.github.com/$GITHUB_REPOSITORY/nginx-oss-s3-gateway:latest
+  #     # Login to Docker Hub
+  #     - name: Login to Docker Hub
+  #       uses: docker/login-action@v1
+  #       with:
+  #         username: ${{ secrets.DOCKER_HUB_USERNAME }}
+  #         password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+  #     # latest-njs-oss image push [Docker Hub]
+  #     - name: Tag container image for Push to Docker Hub [latest-njs-oss date]
+  #       run: docker tag nginx-s3-gateway:latest-njs-oss nginxinc/nginx-s3-gateway:latest-njs-oss-${{ steps.date.outputs.date }}
+  #     - name: Tag container image for Push to Docker Hub [latest-njs-oss]
+  #       run: docker tag nginx-s3-gateway:latest-njs-oss nginxinc/nginx-s3-gateway:latest-njs-oss
+  #     - name: Push container image to Docker Hub [latest-njs-oss date]
+  #       run: docker push nginxinc/nginx-s3-gateway:latest-njs-oss-${{ steps.date.outputs.date }}
+  #     - name: Push container image to Docker Hub [latest-njs-oss]
+  #       run: docker push nginxinc/nginx-s3-gateway:latest-njs-oss
+  #     # unprivileged-oss image push [Docker Hub]
+  #     - name: Tag container image for Push to Docker Hub [unprivileged-oss date]
+  #       run: docker tag nginx-s3-gateway:unprivileged-oss nginxinc/nginx-s3-gateway:unprivileged-oss-${{ steps.date.outputs.date }}
+  #     - name: Tag container image for Push to Docker Hub [unprivileged-oss]
+  #       run: docker tag nginx-s3-gateway:unprivileged-oss nginxinc/nginx-s3-gateway:unprivileged-oss
+  #     - name: Push container image to Docker Hub [unprivileged-oss date]
+  #       run: docker push nginxinc/nginx-s3-gateway:unprivileged-oss-${{ steps.date.outputs.date }}
+  #     - name: Push container image to Docker Hub [unprivileged-oss]
+  #       run: docker push nginxinc/nginx-s3-gateway:unprivileged-oss
+  #     # oss image push [Docker Hub]
+  #     - name: Tag container image for Push to Docker Hub [oss date]
+  #       run: docker tag nginx-s3-gateway:oss nginxinc/nginx-s3-gateway:latest-${{ steps.date.outputs.date }}
+  #     - name: Tag container image for Push to Docker Hub [oss]
+  #       run: docker tag nginx-s3-gateway:oss nginxinc/nginx-s3-gateway:latest
+  #     - name: Push container image to Docker Hub [oss date]
+  #       run: docker push nginxinc/nginx-s3-gateway:latest-${{ steps.date.outputs.date }}
+  #     - name: Push container image to Docker Hub [oss latest]
+  #       run: docker push nginxinc/nginx-s3-gateway:latest

--- a/test.sh
+++ b/test.sh
@@ -297,36 +297,40 @@ trap finish EXIT ERR SIGTERM SIGINT
 
 ### BUILD
 
-# p "Building NGINX S3 gateway Docker image"
-# if [ "${nginx_type}" = "plus" ]; then
-#   if docker buildx > /dev/null 2>&1; then
-#     p "Building using BuildKit"
-#     export DOCKER_BUILDKIT=1
-#     docker buildx build -f Dockerfile.buildkit.${nginx_type} \
-#       --secret id=nginx-crt,src=plus/etc/ssl/nginx/nginx-repo.crt \
-#       --secret id=nginx-key,src=plus/etc/ssl/nginx/nginx-repo.key \
-#       --no-cache \
-#       --tag nginx-s3-gateway --tag nginx-s3-gateway:${nginx_type} .
-#   else
-#     docker build -f Dockerfile.${nginx_type} \
-#       --tag nginx-s3-gateway --tag nginx-s3-gateway:${nginx_type} .
-#   fi
-# else
-#   docker build -f Dockerfile.${nginx_type} \
-#     --tag nginx-s3-gateway --tag nginx-s3-gateway:${nginx_type} .
-# fi
+if [ "$CI" = "true" ]; then
+    echo "Skipping docker image build due to CI=true"
+else
+  p "Building NGINX S3 gateway Docker image"
+  if [ "${nginx_type}" = "plus" ]; then
+    if docker buildx > /dev/null 2>&1; then
+      p "Building using BuildKit"
+      export DOCKER_BUILDKIT=1
+      docker buildx build -f Dockerfile.buildkit.${nginx_type} \
+        --secret id=nginx-crt,src=plus/etc/ssl/nginx/nginx-repo.crt \
+        --secret id=nginx-key,src=plus/etc/ssl/nginx/nginx-repo.key \
+        --no-cache \
+        --tag nginx-s3-gateway --tag nginx-s3-gateway:${nginx_type} .
+    else
+      docker build -f Dockerfile.${nginx_type} \
+        --tag nginx-s3-gateway --tag nginx-s3-gateway:${nginx_type} .
+    fi
+  else
+    docker build -f Dockerfile.${nginx_type} \
+      --tag nginx-s3-gateway --tag nginx-s3-gateway:${nginx_type} .
+  fi
 
-# if [ ${njs_latest} -eq 1 ]; then
-#   p "Layering in latest NJS build"
-#   docker build -f Dockerfile.latest-njs \
-#     --tag nginx-s3-gateway --tag nginx-s3-gateway:latest-njs-${nginx_type} .
-# fi
+  if [ ${njs_latest} -eq 1 ]; then
+    p "Layering in latest NJS build"
+    docker build -f Dockerfile.latest-njs \
+      --tag nginx-s3-gateway --tag nginx-s3-gateway:latest-njs-${nginx_type} .
+  fi
 
-# if [ ${unprivileged} -eq 1 ]; then
-#   p "Layering in unprivileged build"
-#   docker build -f Dockerfile.unprivileged \
-#     --tag nginx-s3-gateway --tag nginx-s3-gateway:unprivileged-${nginx_type} .
-# fi
+  if [ ${unprivileged} -eq 1 ]; then
+    p "Layering in unprivileged build"
+    docker build -f Dockerfile.unprivileged \
+      --tag nginx-s3-gateway --tag nginx-s3-gateway:unprivileged-${nginx_type} .
+  fi
+fi
 
 ### UNIT TESTS
 

--- a/test.sh
+++ b/test.sh
@@ -297,36 +297,36 @@ trap finish EXIT ERR SIGTERM SIGINT
 
 ### BUILD
 
-p "Building NGINX S3 gateway Docker image"
-if [ "${nginx_type}" = "plus" ]; then
-  if docker buildx > /dev/null 2>&1; then
-    p "Building using BuildKit"
-    export DOCKER_BUILDKIT=1
-    docker buildx build -f Dockerfile.buildkit.${nginx_type} \
-      --secret id=nginx-crt,src=plus/etc/ssl/nginx/nginx-repo.crt \
-      --secret id=nginx-key,src=plus/etc/ssl/nginx/nginx-repo.key \
-      --no-cache \
-      --tag nginx-s3-gateway --tag nginx-s3-gateway:${nginx_type} .
-  else
-    docker build -f Dockerfile.${nginx_type} \
-      --tag nginx-s3-gateway --tag nginx-s3-gateway:${nginx_type} .
-  fi
-else
-  docker build -f Dockerfile.${nginx_type} \
-    --tag nginx-s3-gateway --tag nginx-s3-gateway:${nginx_type} .
-fi
+# p "Building NGINX S3 gateway Docker image"
+# if [ "${nginx_type}" = "plus" ]; then
+#   if docker buildx > /dev/null 2>&1; then
+#     p "Building using BuildKit"
+#     export DOCKER_BUILDKIT=1
+#     docker buildx build -f Dockerfile.buildkit.${nginx_type} \
+#       --secret id=nginx-crt,src=plus/etc/ssl/nginx/nginx-repo.crt \
+#       --secret id=nginx-key,src=plus/etc/ssl/nginx/nginx-repo.key \
+#       --no-cache \
+#       --tag nginx-s3-gateway --tag nginx-s3-gateway:${nginx_type} .
+#   else
+#     docker build -f Dockerfile.${nginx_type} \
+#       --tag nginx-s3-gateway --tag nginx-s3-gateway:${nginx_type} .
+#   fi
+# else
+#   docker build -f Dockerfile.${nginx_type} \
+#     --tag nginx-s3-gateway --tag nginx-s3-gateway:${nginx_type} .
+# fi
 
-if [ ${njs_latest} -eq 1 ]; then
-  p "Layering in latest NJS build"
-  docker build -f Dockerfile.latest-njs \
-    --tag nginx-s3-gateway --tag nginx-s3-gateway:latest-njs-${nginx_type} .
-fi
+# if [ ${njs_latest} -eq 1 ]; then
+#   p "Layering in latest NJS build"
+#   docker build -f Dockerfile.latest-njs \
+#     --tag nginx-s3-gateway --tag nginx-s3-gateway:latest-njs-${nginx_type} .
+# fi
 
-if [ ${unprivileged} -eq 1 ]; then
-  p "Layering in unprivileged build"
-  docker build -f Dockerfile.unprivileged \
-    --tag nginx-s3-gateway --tag nginx-s3-gateway:unprivileged-${nginx_type} .
-fi
+# if [ ${unprivileged} -eq 1 ]; then
+#   p "Layering in unprivileged build"
+#   docker build -f Dockerfile.unprivileged \
+#     --tag nginx-s3-gateway --tag nginx-s3-gateway:unprivileged-${nginx_type} .
+# fi
 
 ### UNIT TESTS
 


### PR DESCRIPTION
# What
Allows us to push multi-architecture builds for `linux/amd64` and `linux/arm64` on merge to master. Fixes: https://github.com/nginxinc/nginx-s3-gateway/issues/196

The flow looks like this:

```
                                   ┌──────────────────┐        ┌────────────────┐      ┌────────────────┐
    ┌─────────┐     ┌─────────┬────► Build Latest NJS ├────────►Test Latest NJS ├─────►│Push Latest NJS │
    │Build OSS├────►│Test OSS │    └──────────────────┘        └────────────────┘      └────────────────┘
    └─────────┘     └──┬──────┤
                       │      │    ┌──────────────────┐       ┌──────────────────┐     ┌─────────────────┐
                       │      └────►Build Unprivileged├───────►Test Unprivileged ├────►│Push Unprivileged│
                       │           └──────────────────┘       └──────────────────┘     ├────────┬────────┘
                       │                                                               ├────────┤
                       └──────────────────────────────────────────────────────────────►│Push OSS│
                                                                                       └────────┘


```
Tests are performed by building the relevant image and tagging it with the image name the tests expect.  This follows the original implementation in `test.sh`.  This will likely change to an explicit image name specification as we move the test suite in to Javascript but it's being maintained for now in the interest of simplicity.

## Goals
* To decouple image build from the test run. This will help as we refactor the test suite for this issue https://github.com/nginxinc/nginx-s3-gateway/issues/191.
* Not have CI take a long time due to multi-architecture builds for interim pushes to pull requests.
* CI should fail fast if any of the image builds or tests fail
* Parallelize builds as much as possible.


## Notes
* Since the `unprivileged` and `latest-njs` images build off the base `oss` image, there were some strange moves that had to be done to make that work without rebuilding the base image every time. Specifically, we had to set `setup-buildx-action` to run in `docker` driver mode so we can simply `load` the base image. Otherwise we would have had to use a local repository.  However, in `docker` mode `upload-artifact` doesn't like the file produced so we have to save the file again.
* I wanted to build images once and then run tests against them and push at the end. However, there was not a clean way to get the full multi-architecture images all the way to the push step so I just build them again against all architectures and perform tests in the runner architecture.  This saves us from needing conditionals in the test portions.