### PR TITLE
fix and issue where final build cannot find the base image for build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -229,9 +229,9 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [test-oss, test-latest-njs, test-unprivileged]
 
-    if: |
-      github.ref == 'refs/heads/master' ||
-      github.ref == 'refs/heads/main'
+    # if: |
+    #   github.ref == 'refs/heads/master' ||
+    #   github.ref == 'refs/heads/main'
     services:
       registry:
         image: registry:2
@@ -268,12 +268,6 @@ jobs:
         with:
           platforms: linux/amd64,linux/arm64
 
-      - name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_HUB_USERNAME }}
-          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -293,8 +287,6 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}/nginx-oss-s3-gateway:latest-${{ steps.date.outputs.date }}
             ghcr.io/${{ github.repository }}/nginx-oss-s3-gateway:latest
-            nginxinc/nginx-s3-gateway:latest-${{ steps.date.outputs.date }}
-            nginxinc/nginx-s3-gateway:latest
 
       - name: Build and push image [latest-njs]
         uses: docker/build-push-action@v5
@@ -309,8 +301,6 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}/nginx-oss-s3-gateway:latest-njs-oss-${{ steps.date.outputs.date }}
             ghcr.io/${{ github.repository }}/nginx-oss-s3-gateway:latest-njs-oss
-            nginxinc/nginx-s3-gateway:latest-njs-oss-${{ steps.date.outputs.date }}
-            nginxinc/nginx-s3-gateway:latest-njs-oss
 
       - name: Build and push image [unprivileged]
         uses: docker/build-push-action@v5
@@ -325,5 +315,3 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}/nginx-oss-s3-gateway:unprivileged-oss-${{ steps.date.outputs.date }}
             ghcr.io/${{ github.repository }}/nginx-oss-s3-gateway:unprivileged-oss
-            nginxinc/nginx-s3-gateway:unprivileged-oss-${{ steps.date.outputs.date }}
-            nginxinc/nginx-s3-gateway:unprivileged-oss

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -261,7 +261,7 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           provenance: false
-          tags: localhost:5000/nginx-oss-s3-gateway
+          tags: localhost:5000/nginx-oss-s3-gateway:oss
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -289,7 +289,7 @@ jobs:
           file: Dockerfile.latest-njs
           context: .
           build-contexts: |
-            nginx-s3-gateway=docker-image://localhost:5000/nginx-s3-gateway
+            nginx-s3-gateway=docker-image://localhost:5000/nginx-s3-gateway:oss
           push: true
           platforms: linux/amd64,linux/arm64
           provenance: false
@@ -297,16 +297,16 @@ jobs:
             ghcr.io/${{ github.repository }}/nginx-oss-s3-gateway:latest-njs-oss-${{ steps.date.outputs.date }}
             ghcr.io/${{ github.repository }}/nginx-oss-s3-gateway:latest-njs-oss
 
-      - name: Build and push image [unprivileged]
-        uses: docker/build-push-action@v5
-        with:
-          file: Dockerfile.unprivileged
-          context: .
-          build-contexts: |
-            nginx-s3-gateway=docker-image://localhost:5000/nginx-s3-gateway
-          push: true
-          platforms: linux/amd64,linux/arm64
-          provenance: false
-          tags: |
-            ghcr.io/${{ github.repository }}/nginx-oss-s3-gateway:unprivileged-oss-${{ steps.date.outputs.date }}
-            ghcr.io/${{ github.repository }}/nginx-oss-s3-gateway:unprivileged-oss
+      # - name: Build and push image [unprivileged]
+      #   uses: docker/build-push-action@v5
+      #   with:
+      #     file: Dockerfile.unprivileged
+      #     context: .
+      #     build-contexts: |
+      #       nginx-s3-gateway=docker-image://localhost:5000/nginx-s3-gateway:oss
+      #     push: true
+      #     platforms: linux/amd64,linux/arm64
+      #     provenance: false
+      #     tags: |
+      #       ghcr.io/${{ github.repository }}/nginx-oss-s3-gateway:unprivileged-oss-${{ steps.date.outputs.date }}
+      #       ghcr.io/${{ github.repository }}/nginx-oss-s3-gateway:unprivileged-oss

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -270,6 +270,12 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_HUB_USERNAME }}
+          password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
       # This second invocation of build/push should just use the existing build cache
       - name: Build and push image [oss]
         uses: docker/build-push-action@v5
@@ -282,6 +288,8 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}/nginx-oss-s3-gateway:latest-${{ steps.date.outputs.date }}
             ghcr.io/${{ github.repository }}/nginx-oss-s3-gateway:latest
+            nginxinc/nginx-s3-gateway:latest-${{ steps.date.outputs.date }}
+            nginxinc/nginx-s3-gateway:latest
 
       - name: Build and push image [latest-njs]
         uses: docker/build-push-action@v5
@@ -296,6 +304,8 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}/nginx-oss-s3-gateway:latest-njs-oss-${{ steps.date.outputs.date }}
             ghcr.io/${{ github.repository }}/nginx-oss-s3-gateway:latest-njs-oss
+            nginxinc/nginx-s3-gateway:latest-njs-oss-${{ steps.date.outputs.date }}
+            nginxinc/nginx-s3-gateway:latest-njs-oss
 
       - name: Build and push image [unprivileged]
         uses: docker/build-push-action@v5
@@ -310,3 +320,5 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}/nginx-oss-s3-gateway:unprivileged-oss-${{ steps.date.outputs.date }}
             ghcr.io/${{ github.repository }}/nginx-oss-s3-gateway:unprivileged-oss
+            nginxinc/nginx-s3-gateway:unprivileged-oss-${{ steps.date.outputs.date }}
+            nginxinc/nginx-s3-gateway:unprivileged-oss

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -289,7 +289,7 @@ jobs:
           file: Dockerfile.latest-njs
           context: .
           build-contexts: |
-            nginx-s3-gateway=docker-image://localhost:5000/nginx-s3-gateway:oss
+            nginx-s3-gateway=docker-image://localhost:5000/nginx-oss-s3-gateway:oss
           push: true
           platforms: linux/amd64,linux/arm64
           provenance: false
@@ -297,16 +297,16 @@ jobs:
             ghcr.io/${{ github.repository }}/nginx-oss-s3-gateway:latest-njs-oss-${{ steps.date.outputs.date }}
             ghcr.io/${{ github.repository }}/nginx-oss-s3-gateway:latest-njs-oss
 
-      # - name: Build and push image [unprivileged]
-      #   uses: docker/build-push-action@v5
-      #   with:
-      #     file: Dockerfile.unprivileged
-      #     context: .
-      #     build-contexts: |
-      #       nginx-s3-gateway=docker-image://localhost:5000/nginx-s3-gateway:oss
-      #     push: true
-      #     platforms: linux/amd64,linux/arm64
-      #     provenance: false
-      #     tags: |
-      #       ghcr.io/${{ github.repository }}/nginx-oss-s3-gateway:unprivileged-oss-${{ steps.date.outputs.date }}
-      #       ghcr.io/${{ github.repository }}/nginx-oss-s3-gateway:unprivileged-oss
+      - name: Build and push image [unprivileged]
+        uses: docker/build-push-action@v5
+        with:
+          file: Dockerfile.unprivileged
+          context: .
+          build-contexts: |
+            nginx-s3-gateway=docker-image://localhost:5000/nginx-oss-s3-gateway:oss
+          push: true
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+          tags: |
+            ghcr.io/${{ github.repository }}/nginx-oss-s3-gateway:unprivileged-oss-${{ steps.date.outputs.date }}
+            ghcr.io/${{ github.repository }}/nginx-oss-s3-gateway:unprivileged-oss

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -232,6 +232,12 @@ jobs:
     if: |
       github.ref == 'refs/heads/master' ||
       github.ref == 'refs/heads/main'
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
+
     steps:
       - uses: actions/checkout@v4
       - name: Get current date
@@ -239,15 +245,35 @@ jobs:
         run: echo "date=$(date +'%Y%m%d')" >> $GITHUB_OUTPUT
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
+      - name: Set up Docker Buildx for local image build and push
         uses: docker/setup-buildx-action@v3
         with:
           platforms: linux/amd64,linux/arm64
+          driver-opts: network=host
+
+      # Do an initial build of the base image and push to a local registry for downstream
+      # images because the `docker-container` driver can't find local images with `load`
+      - name: Build and push image [oss] to local registry for downstream
+        uses: docker/build-push-action@v5
+        with:
+          file: Dockerfile.oss
+          context: .
+          push: true
+          platforms: linux/amd64,linux/arm64
+          provenance: false
+          tags: localhost:5000/nginx-oss-s3-gateway
+
+      - name: Set up Docker Buildx for final builds
+        uses: docker/setup-buildx-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64
+
       - name: Login to Docker Hub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
+
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -255,6 +281,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # This second invocation of build/push should just use the existing build cache
       - name: Build and push image [oss]
         uses: docker/build-push-action@v5
         with:
@@ -274,6 +301,8 @@ jobs:
         with:
           file: Dockerfile.latest-njs
           context: .
+          build-contexts: |
+            builder=docker-image://localhost:5000/nginx-oss-s3-gateway
           push: true
           platforms: linux/amd64,linux/arm64
           provenance: false
@@ -288,6 +317,8 @@ jobs:
         with:
           file: Dockerfile.unprivileged
           context: .
+          build-contexts: |
+            builder=docker-image://localhost:5000/nginx-oss-s3-gateway
           push: true
           platforms: linux/amd64,linux/arm64
           provenance: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -229,9 +229,9 @@ jobs:
     runs-on: ubuntu-22.04
     needs: [test-oss, test-latest-njs, test-unprivileged]
 
-    # if: |
-    #   github.ref == 'refs/heads/master' ||
-    #   github.ref == 'refs/heads/main'
+    if: |
+      github.ref == 'refs/heads/master' ||
+      github.ref == 'refs/heads/main'
     services:
       registry:
         image: registry:2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -289,7 +289,7 @@ jobs:
           file: Dockerfile.latest-njs
           context: .
           build-contexts: |
-            builder=docker-image://localhost:5000/nginx-oss-s3-gateway
+            nginx-s3-gateway=docker-image://localhost:5000/nginx-s3-gateway
           push: true
           platforms: linux/amd64,linux/arm64
           provenance: false
@@ -303,7 +303,7 @@ jobs:
           file: Dockerfile.unprivileged
           context: .
           build-contexts: |
-            builder=docker-image://localhost:5000/nginx-oss-s3-gateway
+            nginx-s3-gateway=docker-image://localhost:5000/nginx-s3-gateway
           push: true
           platforms: linux/amd64,linux/arm64
           provenance: false

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -263,11 +263,6 @@ jobs:
           provenance: false
           tags: localhost:5000/nginx-oss-s3-gateway
 
-      - name: Set up Docker Buildx for final builds
-        uses: docker/setup-buildx-action@v3
-        with:
-          platforms: linux/amd64,linux/arm64
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
The original pull request https://github.com/nginxinc/nginx-s3-gateway/pull/197 had an issue where the final build and push could not find the base image locally.

This change corrects the issue but introducing a local registry to the final build push step as described in https://docs.docker.com/build/ci/github-actions/named-contexts/#using-with-a-container-builder since the `docker-container` driver-based build can't load from the local docker environment.