### PR TITLE
fix: Solve an issue where rewrites due to APPEND_SLASH_FOR_POSSIBLE_DIRECTORY would cause duplication of the query string

### DIFF
--- a/common/etc/nginx/templates/default.conf.template
+++ b/common/etc/nginx/templates/default.conf.template
@@ -332,7 +332,9 @@ server {
 
     location @trailslash {
         # 302 to request without slashes
-        rewrite ^ $scheme://$http_host$uri/$is_args$query_string redirect;
+        # Adding a ? to the end of the replacement param in `rewrite` prevents it from
+        # appending the query string.
+        rewrite ^ $scheme://$http_host$uri/$is_args$query_string? redirect;
     }
 
     # Provide a hint to the client on 405 errors of the acceptable request methods


### PR DESCRIPTION
# What
As reported here https://github.com/nginxinc/nginx-s3-gateway/issues/205 when 
* `APPEND_SLASH_FOR_POSSIBLE_DIRECTORY=true`
* `ALLOW_DIRECTORY_LIST=false`
* `PROVIDE_INDEX_PAGE=true`
Are set, requests containing query strings without a trailing slash were being duplicated (`foo?a=b` were becoming `foo?a=b?a=b`).

## Cause
The `rewrite` directive will automatically append the query string unless a final trailing `?` is supplied. This was causing the duplication

## Fix
Added an explanatory comment and a trailing `?` to the rewrite rule to prevent automatic appending of the query string as we already do it in the argument to the rewrite rule.

I chose to do this rather than depending on the default behavior of `rewrite` since the rule as it is expressed is more explicit.  The trailing `?` is mysterious and so a comment was included to clarify.