### PR TITLE
Move latest-njs testing to the -m module for forwards compatibility

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -320,7 +320,10 @@ else
       --tag nginx-s3-gateway --tag nginx-s3-gateway:${nginx_type} .
   fi
 
+  unit_test_command="-t module -p '/etc/nginx'"
+
   if [ ${njs_latest} -eq 1 ]; then
+    unit_test_command="-m -p '/etc/nginx'"
     p "Layering in latest NJS build"
     docker build -f Dockerfile.latest-njs \
       --tag nginx-s3-gateway --tag nginx-s3-gateway:latest-njs-${nginx_type} .
@@ -338,48 +341,92 @@ fi
 runUnitTestWithOutSessionToken() {
   test_code="$1"
 
-  #MSYS_NO_PATHCONV=1 added to resolve automatic path conversion
-  # https://github.com/docker/for-win/issues/6754#issuecomment-629702199
-  MSYS_NO_PATHCONV=1 "${docker_cmd}" run  \
-    --rm                                  \
-    -v "$(pwd)/test/unit:/var/tmp"        \
-    --workdir /var/tmp                    \
-    -e "DEBUG=true"                       \
-    -e "S3_STYLE=virtual"                 \
-    -e "AWS_ACCESS_KEY_ID=unit_test"      \
-    -e "AWS_SECRET_ACCESS_KEY=unit_test"  \
-    -e "S3_BUCKET_NAME=unit_test"         \
-    -e "S3_SERVER=unit_test"              \
-    -e "S3_SERVER_PROTO=https"            \
-    -e "S3_SERVER_PORT=443"               \
-    -e "S3_REGION=test-1"                 \
-    -e "AWS_SIGS_VERSION=4"               \
-    --entrypoint /usr/bin/njs             \
-    nginx-s3-gateway -m -p '/etc/nginx' /var/tmp/"${test_code}"
+  if [ ${njs_latest} -eq 1 ]
+    then
+      #MSYS_NO_PATHCONV=1 added to resolve automatic path conversion
+      # https://github.com/docker/for-win/issues/6754#issuecomment-629702199
+      MSYS_NO_PATHCONV=1 "${docker_cmd}" run  \
+        --rm                                  \
+        -v "$(pwd)/test/unit:/var/tmp"        \
+        --workdir /var/tmp                    \
+        -e "DEBUG=true"                       \
+        -e "S3_STYLE=virtual"                 \
+        -e "AWS_ACCESS_KEY_ID=unit_test"      \
+        -e "AWS_SECRET_ACCESS_KEY=unit_test"  \
+        -e "S3_BUCKET_NAME=unit_test"         \
+        -e "S3_SERVER=unit_test"              \
+        -e "S3_SERVER_PROTO=https"            \
+        -e "S3_SERVER_PORT=443"               \
+        -e "S3_REGION=test-1"                 \
+        -e "AWS_SIGS_VERSION=4"               \
+        --entrypoint /usr/bin/njs             \
+        nginx-s3-gateway -m -p '/etc/nginx' /var/tmp/"${test_code}"
+    else
+      #MSYS_NO_PATHCONV=1 added to resolve automatic path conversion
+      # https://github.com/docker/for-win/issues/6754#issuecomment-629702199
+      MSYS_NO_PATHCONV=1 "${docker_cmd}" run  \
+        --rm                                  \
+        -v "$(pwd)/test/unit:/var/tmp"        \
+        --workdir /var/tmp                    \
+        -e "DEBUG=true"                       \
+        -e "S3_STYLE=virtual"                 \
+        -e "AWS_ACCESS_KEY_ID=unit_test"      \
+        -e "AWS_SECRET_ACCESS_KEY=unit_test"  \
+        -e "S3_BUCKET_NAME=unit_test"         \
+        -e "S3_SERVER=unit_test"              \
+        -e "S3_SERVER_PROTO=https"            \
+        -e "S3_SERVER_PORT=443"               \
+        -e "S3_REGION=test-1"                 \
+        -e "AWS_SIGS_VERSION=4"               \
+        --entrypoint /usr/bin/njs             \
+        nginx-s3-gateway -t module -p '/etc/nginx' /var/tmp/"${test_code}"
+  fi
 }
 
 runUnitTestWithSessionToken() {
   test_code="$1"
-
-  #MSYS_NO_PATHCONV=1 added to resolve automatic path conversion
-  # https://github.com/docker/for-win/issues/6754#issuecomment-629702199
-  MSYS_NO_PATHCONV=1 "${docker_cmd}" run  \
-    --rm                                  \
-    -v "$(pwd)/test/unit:/var/tmp"        \
-    --workdir /var/tmp                    \
-    -e "DEBUG=true"                       \
-    -e "S3_STYLE=virtual"                 \
-    -e "AWS_ACCESS_KEY_ID=unit_test"      \
-    -e "AWS_SECRET_ACCESS_KEY=unit_test"  \
-    -e "AWS_SESSION_TOKEN=unit_test"      \
-    -e "S3_BUCKET_NAME=unit_test"         \
-    -e "S3_SERVER=unit_test"              \
-    -e "S3_SERVER_PROTO=https"            \
-    -e "S3_SERVER_PORT=443"               \
-    -e "S3_REGION=test-1"                 \
-    -e "AWS_SIGS_VERSION=4"               \
-    --entrypoint /usr/bin/njs             \
-    nginx-s3-gateway -m -p '/etc/nginx' /var/tmp/"${test_code}"
+  if [ ${njs_latest} -eq 1 ]
+    then
+      #MSYS_NO_PATHCONV=1 added to resolve automatic path conversion
+      # https://github.com/docker/for-win/issues/6754#issuecomment-629702199
+      MSYS_NO_PATHCONV=1 "${docker_cmd}" run  \
+        --rm                                  \
+        -v "$(pwd)/test/unit:/var/tmp"        \
+        --workdir /var/tmp                    \
+        -e "DEBUG=true"                       \
+        -e "S3_STYLE=virtual"                 \
+        -e "AWS_ACCESS_KEY_ID=unit_test"      \
+        -e "AWS_SECRET_ACCESS_KEY=unit_test"  \
+        -e "AWS_SESSION_TOKEN=unit_test"      \
+        -e "S3_BUCKET_NAME=unit_test"         \
+        -e "S3_SERVER=unit_test"              \
+        -e "S3_SERVER_PROTO=https"            \
+        -e "S3_SERVER_PORT=443"               \
+        -e "S3_REGION=test-1"                 \
+        -e "AWS_SIGS_VERSION=4"               \
+        --entrypoint /usr/bin/njs             \
+        nginx-s3-gateway -m -p '/etc/nginx' /var/tmp/"${test_code}"
+    else
+      #MSYS_NO_PATHCONV=1 added to resolve automatic path conversion
+      # https://github.com/docker/for-win/issues/6754#issuecomment-629702199
+      MSYS_NO_PATHCONV=1 "${docker_cmd}" run  \
+        --rm                                  \
+        -v "$(pwd)/test/unit:/var/tmp"        \
+        --workdir /var/tmp                    \
+        -e "DEBUG=true"                       \
+        -e "S3_STYLE=virtual"                 \
+        -e "AWS_ACCESS_KEY_ID=unit_test"      \
+        -e "AWS_SECRET_ACCESS_KEY=unit_test"  \
+        -e "AWS_SESSION_TOKEN=unit_test"      \
+        -e "S3_BUCKET_NAME=unit_test"         \
+        -e "S3_SERVER=unit_test"              \
+        -e "S3_SERVER_PROTO=https"            \
+        -e "S3_SERVER_PORT=443"               \
+        -e "S3_REGION=test-1"                 \
+        -e "AWS_SIGS_VERSION=4"               \
+        --entrypoint /usr/bin/njs             \
+        nginx-s3-gateway -t module -p '/etc/nginx' /var/tmp/"${test_code}"
+  fi
 }
 
 p "Running unit tests for utils"

--- a/test.sh
+++ b/test.sh
@@ -340,7 +340,7 @@ fi
 
 runUnitTestWithOutSessionToken() {
   test_code="$1"
-
+  # Temporary hack while njs transitions to supporting -m in the cli tool
   if [ ${njs_latest} -eq 1 ]
     then
       #MSYS_NO_PATHCONV=1 added to resolve automatic path conversion
@@ -385,6 +385,7 @@ runUnitTestWithOutSessionToken() {
 
 runUnitTestWithSessionToken() {
   test_code="$1"
+  # Temporary hack while njs transitions to supporting -m in the cli tool
   if [ ${njs_latest} -eq 1 ]
     then
       #MSYS_NO_PATHCONV=1 added to resolve automatic path conversion

--- a/test.sh
+++ b/test.sh
@@ -355,7 +355,7 @@ runUnitTestWithOutSessionToken() {
     -e "S3_REGION=test-1"                 \
     -e "AWS_SIGS_VERSION=4"               \
     --entrypoint /usr/bin/njs             \
-    nginx-s3-gateway -t module -p '/etc/nginx' /var/tmp/"${test_code}"
+    nginx-s3-gateway -m -p '/etc/nginx' /var/tmp/"${test_code}"
 }
 
 runUnitTestWithSessionToken() {
@@ -379,7 +379,7 @@ runUnitTestWithSessionToken() {
     -e "S3_REGION=test-1"                 \
     -e "AWS_SIGS_VERSION=4"               \
     --entrypoint /usr/bin/njs             \
-    nginx-s3-gateway -t module -p '/etc/nginx' /var/tmp/"${test_code}"
+    nginx-s3-gateway -m -p '/etc/nginx' /var/tmp/"${test_code}"
 }
 
 p "Running unit tests for utils"


### PR DESCRIPTION
# What
njs will be deprecating the `-t` command in its CLI tool. This change uses the `-m` flag to indicate a module instead of `-t`.