### PR TITLE
docs: update community related docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,31 +1,41 @@
 ---
 name: Bug report
 about: Create a report to help us improve
-
+title: ""
+labels: ""
+assignees: ""
 ---
 
-**Describe the bug**
+### Describe the bug
+
 A clear and concise description of what the bug is.
 
-**To Reproduce**
+### To reproduce
+
 Steps to reproduce the behavior:
-1. Start container with x/y arguments
-2. View logs on '....'
+
+1. Start container with [...] arguments
+2. View output/logs/configuration on [...]
 3. See error
 
-**Expected behavior**
+### Expected behavior
+
 A clear and concise description of what you expected to happen.
 
-**Your environment**
-* Version of the repo - a specific commit or tag
-* Version of the container used (if downloaded from Docker Hub or Github)
-* S3 backend implementation you are using (AWS, Ceph, NetApp StorageGrid, etc)
-* How you are deploying Docker/Stand-alone, etc
-* NGINX type (OSS/Plus)
-* Authentication method (IAM, IAM with Fargate, IAM with K8S, AWS Credentials, etc)
+### Your environment
 
-**Additional context**
-Add any other context about the problem here. Any log files you want to share.
+- Version of the S3 container used (when downloaded from either Docker Hub or the GitHub Container Registry)
+- Version of this project or specific commit when building your own S3 container
+- Version of NGINX Open Source or NGINX Plus (OSS/Plus)
+- Version of NGINX JavaScript
+- Target deployment platform for the S3 container
+- S3 backend implementation (AWS, Ceph, NetApp StorageGrid, etc...)
+- Authentication method (IAM, IAM with Fargate, IAM with K8S, AWS Credentials, etc...)
 
-**Sensitive Information**
-Be sure to redact any sensitive information such as your AWS authentication keys.
+### Additional context
+
+Add any other context about the problem here.
+
+### Sensitive Information
+
+Remember to redact any sensitive information such as authentication credentials or license keys.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,17 +1,23 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-
+title: ""
+labels: ""
+assignees: ""
 ---
 
-**Is your feature request related to a problem? Please describe.**
+### Is your feature request related to a problem? Please describe
+
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
+### Describe the solution you'd like
+
 A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
+### Describe alternatives you've considered
+
 A clear and concise description of any alternative solutions or features you've considered.
 
-**Additional context**
+### Additional context
+
 Add any other context or screenshots about the feature request here.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,12 +1,12 @@
 ### Proposed changes
 
-Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) here in this description (not in the title of the PR).
+Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in this PR description (not in the title of the PR).
 
 ### Checklist
 
 Before creating a PR, run through this checklist and mark each as complete:
 
-- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-s3-gateway/blob/main/CONTRIBUTING.md) document.
+- [ ] I have read the [`contributing guidelines`](/CONTRIBUTING.md).
 - [ ] If applicable, I have added tests that prove my fix is effective or that my feature works.
 - [ ] If applicable, I have checked that any relevant tests pass after adding my changes.
-- [ ] I have updated any relevant documentation (e.g. [`README.md`](https://github.com/nginxinc/nginx-s3-gateway/blob/main/README.md)).
+- [ ] I have updated any relevant documentation (e.g. [`README.md`](/README.md)).

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,12 @@
+### Proposed changes
+
+Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) here in this description (not in the title of the PR).
+
+### Checklist
+
+Before creating a PR, run through this checklist and mark each as complete:
+
+- [ ] I have read the [`CONTRIBUTING`](https://github.com/nginxinc/nginx-s3-gateway/blob/main/CONTRIBUTING.md) document.
+- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works.
+- [ ] If applicable, I have checked that any relevant tests pass after adding my changes.
+- [ ] I have updated any relevant documentation (e.g. [`README.md`](https://github.com/nginxinc/nginx-s3-gateway/blob/main/README.md)).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -10,20 +10,19 @@ We pledge to act and interact in ways that contribute to an open, welcoming, div
 
 Examples of behavior that contributes to a positive environment for our community include:
 
-- Demonstrating empathy and kindness toward other people
-- Being respectful of differing opinions, viewpoints, and experiences
-- Giving and gracefully accepting constructive feedback
-- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
-- Focusing on what is best not just for us as individuals, but for the overall community
+- Demonstrating empathy and kindness toward other people.
+- Being respectful of differing opinions, viewpoints, and experiences.
+- Giving and gracefully accepting constructive feedback.
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience.
+- Focusing on what is best not just for us as individuals, but for the overall community.
 
 Examples of unacceptable behavior include:
 
-- The use of sexualized language or imagery, and sexual attention or advances of
-  any kind
-- Trolling, insulting or derogatory comments, and personal or political attacks
-- Public or private harassment
-- Publishing others' private information, such as a physical or email address, without their explicit permission
-- Other conduct which could reasonably be considered inappropriate in a professional setting
+- The use of sexualized language or imagery, and sexual attention or advances of any kind.
+- Trolling, insulting or derogatory comments, and personal or political attacks.
+- Public or private harassment.
+- Publishing others' private information, such as a physical or email address, without their explicit permission.
+- Other conduct which could reasonably be considered inappropriate in a professional setting.
 
 ## Enforcement Responsibilities
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,129 +1,79 @@
-
 # Contributor Covenant Code of Conduct
 
 ## Our Pledge
 
-We as members, contributors, and leaders pledge to make participation in our
-community a harassment-free experience for everyone, regardless of age, body
-size, visible or invisible disability, ethnicity, sex characteristics, gender
-identity and expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, religion, or sexual identity
-and orientation.
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
 
-We pledge to act and interact in ways that contribute to an open, welcoming,
-diverse, inclusive, and healthy community.
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
 
 ## Our Standards
 
-Examples of behavior that contributes to a positive environment for our
-community include:
+Examples of behavior that contributes to a positive environment for our community include:
 
-* Demonstrating empathy and kindness toward other people
-* Being respectful of differing opinions, viewpoints, and experiences
-* Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
-  and learning from the experience
-* Focusing on what is best not just for us as individuals, but for the
-  overall community
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall community
 
 Examples of unacceptable behavior include:
 
-* The use of sexualized language or imagery, and sexual attention or
-  advances of any kind
-* Trolling, insulting or derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others' private information, such as a physical or email
-  address, without their explicit permission
-* Other conduct which could reasonably be considered inappropriate in a
-  professional setting
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address, without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
 
 ## Enforcement Responsibilities
 
-Community leaders are responsible for clarifying and enforcing our standards of
-acceptable behavior and will take appropriate and fair corrective action in
-response to any behavior that they deem inappropriate, threatening, offensive,
-or harmful.
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
 
-Community leaders have the right and responsibility to remove, edit, or reject
-comments, commits, code, wiki edits, issues, and other contributions that are
-not aligned to this Code of Conduct, and will communicate reasons for moderation
-decisions when appropriate.
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
 
 ## Scope
 
-This Code of Conduct applies within all community spaces, and also applies when
-an individual is officially representing the community in public spaces.
-Examples of representing our community include using an official e-mail address,
-posting via an official social media account, or acting as an appointed
-representative at an online or offline event.
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement as listed on the
-github project page.
-All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at <nginx-oss-community@f5.com>. All complaints will be reviewed and investigated promptly and fairly.
 
-All community leaders are obligated to respect the privacy and security of the
-reporter of any incident.
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 
 ## Enforcement Guidelines
 
-Community leaders will follow these Community Impact Guidelines in determining
-the consequences for any action they deem in violation of this Code of Conduct:
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
 
 ### 1. Correction
 
-**Community Impact**: Use of inappropriate language or other behavior deemed
-unprofessional or unwelcome in the community.
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
 
-**Consequence**: A private, written warning from community leaders, providing
-clarity around the nature of the violation and an explanation of why the
-behavior was inappropriate. A public apology may be requested.
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
 
 ### 2. Warning
 
-**Community Impact**: A violation through a single incident or series
-of actions.
+**Community Impact**: A violation through a single incident or series of actions.
 
-**Consequence**: A warning with consequences for continued behavior. No
-interaction with the people involved, including unsolicited interaction with
-those enforcing the Code of Conduct, for a specified period of time. This
-includes avoiding interactions in community spaces as well as external channels
-like social media. Violating these terms may lead to a temporary or
-permanent ban.
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
 
 ### 3. Temporary Ban
 
-**Community Impact**: A serious violation of community standards, including
-sustained inappropriate behavior.
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
 
-**Consequence**: A temporary ban from any sort of interaction or public
-communication with the community for a specified period of time. No public or
-private interaction with the people involved, including unsolicited interaction
-with those enforcing the Code of Conduct, is allowed during this period.
-Violating these terms may lead to a permanent ban.
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
 
 ### 4. Permanent Ban
 
-**Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior,  harassment of an
-individual, or aggression toward or disparagement of classes of individuals.
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
 
-**Consequence**: A permanent ban from any sort of public interaction within
-the community.
+**Consequence**: A permanent ban from any sort of public interaction within the community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-version 2.0, available at
-https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1, available at <https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
 
-Community Impact Guidelines were inspired by [Mozilla's code of conduct
-enforcement ladder](https://github.com/mozilla/diversity).
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/inclusion).
 
-[homepage]: https://www.contributor-covenant.org
-
-For answers to common questions about this code of conduct, see the FAQ at
-https://www.contributor-covenant.org/faq. Translations are available at
-https://www.contributor-covenant.org/translations.
+For answers to common questions about this code of conduct, see the FAQ at <https://www.contributor-covenant.org/faq>. Translations are available at <https://www.contributor-covenant.org/translations>.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,31 +1,51 @@
 # Contributing Guidelines
 
-The following is a set of guidelines for contributing. We really appreciate that you are considering contributing!
+The following is a set of guidelines for contributing to this project. We really appreciate that you are considering contributing!
 
 #### Table Of Contents
 
-[Ask a Question](#ask-a-question)
+[Getting Started](#getting-started)
 
 [Contributing](#contributing)
 
-[Code of Conduct](CODE_OF_CONDUCT.md)
+[Code Guidelines](#code-guidelines)
 
-## Ask a Question
+[Code of Conduct](https://github.com/nginxinc/nginx-s3-gateway/blob/main/CODE_OF_CONDUCT.md)
 
-Please ask your question on github using discussions.
+## Getting Started
+
+Follow our [Getting Started Guide](https://github.com/nginxinc/nginx-s3-gateway/blob/main/README.md#Getting-Started) to get this project up and running.
+
+<!-- ### Project Structure (OPTIONAL) -->
 
 ## Contributing
 
 ### Report a Bug
 
-To report a bug, open an issue on GitHub with the label `bug` using the available bug report issue template. Please ensure the issue has not already been reported.
+To report a bug, open an issue on GitHub with the label `bug` using the available bug report issue template. Please ensure the bug has not already been reported. **If the bug is a potential security vulnerability, please report it using our [security policy](https://github.com/nginxinc/nginx-s3-gateway/blob/main/SECURITY.md).**
 
-### Suggest an Enhancement
+### Suggest a Feature or Enhancement
 
-To suggest an enhancement, please create an issue on GitHub with the label `enhancement` using the available feature issue template.
+To suggest a feature or enhancement, please create an issue on GitHub with the label `enhancement` using the available [feature request template](https://github.com/nginxinc/nginx-s3-gateway/blob/main/.github/feature_request_template.md). Please ensure the feature or enhancement has not already been suggested.
 
 ### Open a Pull Request
 
-* Fork the repo, create a branch, submit a PR when your changes are tested and ready for review.
+- Fork the repo, create a branch, implement your changes, add any relevant tests, submit a PR when your changes are **tested** and ready for review.
+- Fill in [our pull request template](https://github.com/nginxinc/nginx-s3-gateway/blob/main/.github/pull_request_template.md).
 
-Note: if you’d like to implement a new feature, please consider creating a feature request issue first to start a discussion about the feature.
+**Note:** If you'd like to implement a new feature, please consider creating a [feature request issue](https://github.com/nginxinc/nginx-s3-gateway/blob/main/.github/feature_request_template.md) first to start a discussion about the feature.
+
+## Code Guidelines
+
+<!-- ### Go/Python/Bash/etc... Guidelines (OPTIONAL) -->
+
+### Git Guidelines
+
+- Keep a clean, concise and meaningful git commit history on your branch (within reason), rebasing locally and squashing before submitting a PR.
+- If possible and/or relevant, use the [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) format when writing a commit message, so that changelogs can be automatically generated.
+- Follow the guidelines of writing a good commit message as described here <https://chris.beams.io/posts/git-commit/> and summarized in the next few points:
+  - In the subject line, use the present tense ("Add feature" not "Added feature").
+  - In the subject line, use the imperative mood ("Move cursor to..." not "Moves cursor to...").
+  - Limit the subject line to 72 characters or less.
+  - Reference issues and pull requests liberally after the subject line.
+  - Add more detailed description in the body of the git message (`git commit -a` to give you more space and time in your text editor to write a good message instead of `git commit -am`).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ The following is a set of guidelines for contributing to this project. We really
 
 ## Getting Started
 
-Follow our [Getting Started Guide](/README.md#Getting-Started) to get this project up and running.
+Follow the instructions on the README's [Getting Started Guide](/README.md#Getting-Started) section to get this project up and running.
 
 <!-- ### Project Structure (OPTIONAL) -->
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,11 +10,11 @@ The following is a set of guidelines for contributing to this project. We really
 
 [Code Guidelines](#code-guidelines)
 
-[Code of Conduct](https://github.com/nginxinc/nginx-s3-gateway/blob/main/CODE_OF_CONDUCT.md)
+[Code of Conduct](/CODE_OF_CONDUCT.md)
 
 ## Getting Started
 
-Follow our [Getting Started Guide](https://github.com/nginxinc/nginx-s3-gateway/blob/main/README.md#Getting-Started) to get this project up and running.
+Follow our [Getting Started Guide](/README.md#Getting-Started) to get this project up and running.
 
 <!-- ### Project Structure (OPTIONAL) -->
 
@@ -22,18 +22,18 @@ Follow our [Getting Started Guide](https://github.com/nginxinc/nginx-s3-gateway/
 
 ### Report a Bug
 
-To report a bug, open an issue on GitHub with the label `bug` using the available bug report issue template. Please ensure the bug has not already been reported. **If the bug is a potential security vulnerability, please report it using our [security policy](https://github.com/nginxinc/nginx-s3-gateway/blob/main/SECURITY.md).**
+To report a bug, open an issue on GitHub with the label `bug` using the available bug report issue template. Please ensure the bug has not already been reported. **If the bug is a potential security vulnerability, please report it using our [security policy](/SECURITY.md).**
 
 ### Suggest a Feature or Enhancement
 
-To suggest a feature or enhancement, please create an issue on GitHub with the label `enhancement` using the available [feature request template](https://github.com/nginxinc/nginx-s3-gateway/blob/main/.github/feature_request_template.md). Please ensure the feature or enhancement has not already been suggested.
+To suggest a feature or enhancement, please create an issue on GitHub with the label `enhancement` using the available [feature request template](/.github/feature_request_template.md). Please ensure the feature or enhancement has not already been suggested.
 
 ### Open a Pull Request
 
 - Fork the repo, create a branch, implement your changes, add any relevant tests, submit a PR when your changes are **tested** and ready for review.
-- Fill in [our pull request template](https://github.com/nginxinc/nginx-s3-gateway/blob/main/.github/pull_request_template.md).
+- Fill in [our pull request template](/.github/pull_request_template.md).
 
-**Note:** If you'd like to implement a new feature, please consider creating a [feature request issue](https://github.com/nginxinc/nginx-s3-gateway/blob/main/.github/feature_request_template.md) first to start a discussion about the feature.
+**Note:** If you'd like to implement a new feature, please consider creating a [feature request issue](/.github/feature_request_template.md) first to start a discussion about the feature.
 
 ## Code Guidelines
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,3 @@
-
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
-[![CI](https://github.com/nginxinc/nginx-s3-gateway/actions/workflows/main.yml/badge.svg)](https://github.com/nginxinc/nginx-s3-gateway/actions/workflows/main.yml) 
-[![Community Support](https://badgen.net/badge/support/community/cyan?icon=awesome)](https://github.com/nginxinc/nginx-s3-gateway/discussions)
+[![CI](https://github.com/nginxinc/nginx-s3-gateway/actions/workflows/main.yml/badge.svg)](https://github.com/nginxinc/nginx-s3-gateway/actions/workflows/main.yml)
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
-[![Docker Pulls](https://img.shields.io/docker/pulls/nginxinc/nginx-s3-gateway?style=flat)](https://hub.docker.com/repository/docker/nginxinc/nginx-s3-gateway/general)
+[![Community Support](https://badgen.net/badge/support/community/cyan?icon=awesome)](https://github.com/nginxinc/nginx-s3-gateway/blob/main/SUPPORT.md))
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](https://github.com/nginxinc/nginx-s3-gateway/main/CODE_OF_CONDUCT.md)
 
 # NGINX S3 Gateway
 
 ## Introduction
 
-This project provides a working configuration of NGINX configured to act as 
+This project provides a working configuration of NGINX configured to act as
 an authenticating and caching gateway for to AWS S3 or another S3 compatible
 service. This allows you to proxy a private S3 bucket without requiring users
 to authenticate to it. Within the proxy layer, additional functionality can be
@@ -31,12 +31,12 @@ configured such as:
 All such functionality can be enabled within a standard NGINX configuration
 because this project is nothing other than NGINX with additional configuration
 that allows for proxying S3. It can be used as-is if the predefined
-configuration is sufficient, or it can serve as a base example for a more 
+configuration is sufficient, or it can serve as a base example for a more
 customized configuration.
 
 If the predefined configuration does not meet your needs, it is best to borrow
 from the patterns in this project and build your own configuration. For example,
-if you want to enable SSL/TLS and compression in your NGINX S3 gateway 
+if you want to enable SSL/TLS and compression in your NGINX S3 gateway
 configuration, you will need to look at other documentation because this
 project does not enable those features of NGINX.
 
@@ -46,7 +46,7 @@ This project can be run as a stand-alone container or as a Systemd service.
 Both modes use the same NGINX configuration and are functionally equal in terms
 features. However, in the case of running as a Systemd service, other services
 can be configured that additional functionality such as [certbot](https://certbot.eff.org/)
-for [Let's Encrypt](https://letsencrypt.org/) support.    
+for [Let's Encrypt](https://letsencrypt.org/) support.
 
 ## Getting Started
 
@@ -66,7 +66,7 @@ common/                          contains files used by both NGINX OSS and Plus 
 deployments/                     contains files used for deployment technologies such as
                                  CloudFormation
 docs/                            contains documentation about the project
-examples/                        contains additional `Dockerfile` examples that extend the base 
+examples/                        contains additional `Dockerfile` examples that extend the base
                                  configuration
 jsdoc                            JSDoc configuration files
 oss/                             contains files used solely in NGINX OSS configurations
@@ -74,7 +74,7 @@ plus/                            contains files used solely in NGINX Plus config
 test/                            contains automated tests for validang that the examples work
 Dockerfile.oss                   Dockerfile that configures NGINX OSS to act as a S3 gateway
 Dockerfile.plus                  Dockerfile that builds a NGINX Plus instance that is configured
-                                 equivelently to NGINX OSS - instance is configured to act as a 
+                                 equivelently to NGINX OSS - instance is configured to act as a
                                  S3 gateway with NGINX Plus additional features enabled
 Dockerfile.buildkit.plus         Dockerfile with the same configuration as Dockerfile.plus, but
                                  with support for hiding secrets using Docker's Buildkit
@@ -94,6 +94,12 @@ test.sh                          test launcher
 Refer to the [Development Guide](docs/development.md) for more information about
 extending or testing the gateway.
 
+## Contributing
+
+Please see the [contributing guide](https://github.com/nginxinc/nginx-s3-gateway/blob/main/CONTRIBUTING.md) for guidelines on how to best contribute to this project.
+
 ## License
 
-All code include is licensed under the [Apache 2.0 license](LICENSE.txt).
+[Apache License, Version 2.0](https://github.com/nginxinc/nginx-s3-gateway/blob/main/LICENSE)
+
+&copy; [F5, Inc.](https://www.f5.com/) 2024

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![CI](https://github.com/nginxinc/nginx-s3-gateway/actions/workflows/main.yml/badge.svg)](https://github.com/nginxinc/nginx-s3-gateway/actions/workflows/main.yml)
 [![Project Status: Active – The project has reached a stable, usable state and is being actively developed.](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
-[![Community Support](https://badgen.net/badge/support/community/cyan?icon=awesome)](https://github.com/nginxinc/nginx-s3-gateway/blob/main/SUPPORT.md))
-[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](https://github.com/nginxinc/nginx-s3-gateway/main/CODE_OF_CONDUCT.md)
+[![Community Support](https://badgen.net/badge/support/community/cyan?icon=awesome)](/SUPPORT.md))
+[![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](/CODE_OF_CONDUCT.md)
 
 # NGINX S3 Gateway
 
@@ -96,10 +96,10 @@ extending or testing the gateway.
 
 ## Contributing
 
-Please see the [contributing guide](https://github.com/nginxinc/nginx-s3-gateway/blob/main/CONTRIBUTING.md) for guidelines on how to best contribute to this project.
+Please see the [contributing guide](/CONTRIBUTING.md) for guidelines on how to best contribute to this project.
 
 ## License
 
-[Apache License, Version 2.0](https://github.com/nginxinc/nginx-s3-gateway/blob/main/LICENSE)
+[Apache License, Version 2.0](/LICENSE)
 
 &copy; [F5, Inc.](https://www.f5.com/) 2020 - 2024

--- a/README.md
+++ b/README.md
@@ -102,4 +102,4 @@ Please see the [contributing guide](https://github.com/nginxinc/nginx-s3-gateway
 
 [Apache License, Version 2.0](https://github.com/nginxinc/nginx-s3-gateway/blob/main/LICENSE)
 
-&copy; [F5, Inc.](https://www.f5.com/) 2024
+&copy; [F5, Inc.](https://www.f5.com/) 2020 - 2024

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,19 +1,14 @@
 # Security Policy
 
-## General Guidance
+## Latest Versions
 
-We advise users to run the most recent release of the NGINX S3 Gateway, and we issue software updates to the most recent release.
-
-## Support
-
-The NGINX S3 Gateway in and of itself is an unsupported example of a collection of NGINX configuration, containers and njs scripts.
-However, NGINX itself is supported.
+We advise users to run or update to the most recent release of this project. Older versions of this project may not have all enhancements and/or bug fixes applied to them.
 
 ## Reporting a Vulnerability
 
-The F5 Security Incident Response Team (F5 SIRT) has an email alias that makes it easy to report potential security vulnerabilities.
+The F5 Security Incident Response Team (F5 SIRT) has an email alias that makes it easy to report potential security vulnerabilities:
 
 - If you’re an F5 customer with an active support contract, please contact [F5 Technical Support](https://www.f5.com/services/support).
-- If you aren’t an F5 customer, please report any potential or current instances of security vulnerabilities with any F5 product to the F5 Security Incident Response Team at F5SIRT@f5.com
+- If you aren’t an F5 customer, please report any potential or current instances of security vulnerabilities with any F5 product to the F5 Security Incident Response Team at <F5SIRT@f5.com>.
 
-For more information visit https://www.f5.com/services/support/report-a-vulnerability
+For more information visit [https://www.f5.com/services/support/report-a-vulnerability](https://www.f5.com/services/support/report-a-vulnerability).

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -30,7 +30,7 @@ Want to get in touch with the NGINX development team directly? Try using the rel
 
 ## Contributing
 
-Please see the [contributing guide](https://github.com/nginxinc/nginx-s3-gateway/blob/main/CONTRIBUTING.md) for guidelines on how to best contribute to this project.
+Please see the [contributing guide](/CONTRIBUTING.md) for guidelines on how to best contribute to this project.
 
 ## Community Support
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,18 +1,10 @@
 # Support
 
-## Commercial Support
-
-The NGINX S3 Gateway project itself does *not* have a commercial support 
-offering. However, NGINX and njs, the technologies the gateway is built with 
-does have commercial support. This means that the specific configuration and
-Javascript files that make up this solution does not have support, but the
-underlying technologies that run the gateway do have support.
-
 ## Ask a Question
 
 We use GitHub for tracking bugs and feature requests related to this project.
 
-Don't know how something in this project works? Curious if this project can achieve your desired functionality? Please start a discussion on GitHub.
+Don't know how something in this project works? Curious if this project can achieve your desired functionality? Please open an issue on GitHub with the label `question`.
 
 ## NGINX Specific Questions and/or Issues
 
@@ -22,7 +14,7 @@ This isn't the right place to get support for NGINX specific questions, but the 
 
 We have a community [Slack](https://nginxcommunity.slack.com/)!
 
-If you are not a member click [here](https://community.nginx.org/joinslack) to sign up (and let us know if the link does not seem to be working!)
+If you are not a member, click [here](https://community.nginx.org/joinslack) to sign up. (Let us know if the link does not seem to be working at <nginx-oss-community@f5.com>!)
 
 Once you join, check out the `#beginner-questions` and `nginx-users` channels :)
 
@@ -30,7 +22,7 @@ Once you join, check out the `#beginner-questions` and `nginx-users` channels :)
 
 For a comprehensive list of all NGINX directives, check out <https://nginx.org>.
 
-For a comprehensive list of admin and deployment guides for all NGINX products, check out <https://docs.nginx.com>.
+For a comprehensive list of administration and deployment guides for all NGINX products, check out <https://docs.nginx.com>.
 
 ### Mailing List
 
@@ -38,4 +30,8 @@ Want to get in touch with the NGINX development team directly? Try using the rel
 
 ## Contributing
 
-Please see the [contributing guide](CONTRIBUTING.md) for guidelines on how to best contribute to this project.
+Please see the [contributing guide](https://github.com/nginxinc/nginx-s3-gateway/blob/main/CONTRIBUTING.md) for guidelines on how to best contribute to this project.
+
+## Community Support
+
+This project does **not** offer commercial support. Community support is offered on a best effort basis through either GitHub issues/PRs/discussions or via any of our active communities.


### PR DESCRIPTION
Notable differences:
- Add a PR template
- Update Code of Conduct
- Add Contributing link and Copyright notice to README
- Remove Docker pulls vanity metric (vanity metrics are meh) from README
- Minor updates throughout all the community related docs to bring the docs up to speed with the latest community doc guidelines