### PR TITLE
ci(fix): Properly auto-update Dockerfiles using a build arg

### DIFF
--- a/Dockerfile.buildkit.plus
+++ b/Dockerfile.buildkit.plus
@@ -1,8 +1,8 @@
-ARG RELEASE=bookworm
-FROM debian:${RELEASE}-slim@sha256:f528891ab1aa484bf7233dbcc84f3c806c3e427571d75510a9d74bb5ec535b33
+# ARG RELEASE=bookworm # Removing for the time being since it doesn't play well with Dependabot
+FROM debian:bookworm-slim@sha256:f528891ab1aa484bf7233dbcc84f3c806c3e427571d75510a9d74bb5ec535b33
 
-# Persist RELEASE argument
-ARG RELEASE
+# Create RELEASE argument
+ARG RELEASE=bookworm
 
 # NJS env vars
 ENV NGINX_VERSION=32

--- a/Dockerfile.buildkit.plus
+++ b/Dockerfile.buildkit.plus
@@ -1,4 +1,3 @@
-# ARG RELEASE=bookworm # Removing for the time being since it doesn't play well with Dependabot
 FROM debian:bookworm-slim@sha256:f528891ab1aa484bf7233dbcc84f3c806c3e427571d75510a9d74bb5ec535b33
 
 # Create RELEASE argument

--- a/Dockerfile.plus
+++ b/Dockerfile.plus
@@ -1,8 +1,8 @@
-ARG RELEASE=bookworm
-FROM debian:${RELEASE}-slim@sha256:f528891ab1aa484bf7233dbcc84f3c806c3e427571d75510a9d74bb5ec535b33
+# ARG RELEASE=bookworm # Removing for the time being since it doesn't play well with Dependabot
+FROM debian:bookworm-slim@sha256:f528891ab1aa484bf7233dbcc84f3c806c3e427571d75510a9d74bb5ec535b33
 
-# Persist RELEASE argument
-ARG RELEASE
+# Create RELEASE argument
+ARG RELEASE=bookworm
 
 # NJS env vars
 ENV NGINX_VERSION=32

--- a/Dockerfile.plus
+++ b/Dockerfile.plus
@@ -1,4 +1,3 @@
-# ARG RELEASE=bookworm # Removing for the time being since it doesn't play well with Dependabot
 FROM debian:bookworm-slim@sha256:f528891ab1aa484bf7233dbcc84f3c806c3e427571d75510a9d74bb5ec535b33
 
 # Create RELEASE argument


### PR DESCRIPTION
### Proposed changes

Dependabot will not generate PRs for Dockerfiles that include a build argument within their FROM instruction. This PR fixes that issue.

### Checklist

Before creating a pull request (PR), run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md).
- [x] The PR title follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation (e.g. [`README.md`](/README.md)).
