### PR TITLE
fix: Preserve AWS_CONTAINER_CREDENTIALS_RELATIVE_URI in nginx.conf

### DIFF
--- a/common/etc/nginx/nginx.conf
+++ b/common/etc/nginx/nginx.conf
@@ -12,6 +12,7 @@ load_module modules/ngx_http_xslt_filter_module.so;
 env AWS_ACCESS_KEY_ID;
 env AWS_SECRET_ACCESS_KEY;
 env AWS_SESSION_TOKEN;
+env AWS_CONTAINER_CREDENTIALS_RELATIVE_URI;
 env S3_BUCKET_NAME;
 env S3_SERVER;
 env S3_SERVER_PORT;


### PR DESCRIPTION
"AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" is set when "00-check-for-required-env.sh" runs. In "awscredentials.js" -> "fetchCredentials", however, the "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI" is not set anymore and erroneously, "_fetchEC2RoleCredentials" instead of "_fetchEcsRoleCredentials" is called.

### Proposed changes

Describe the use case and detail of the change. If this PR addresses an issue on GitHub, make sure to include a link to that issue using one of the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in this PR description (not in the title of the PR).

### Checklist

Before creating a pull request (PR), run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md).
- [x] The PR title follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation (e.g. [`README.md`](/README.md)).
