### PR TITLE
fix: fixes usage with eks pod identity

### DIFF
--- a/common/docker-entrypoint.d/00-check-for-required-env.sh
+++ b/common/docker-entrypoint.d/00-check-for-required-env.sh
@@ -57,6 +57,16 @@ elif [[ -v AWS_WEB_IDENTITY_TOKEN_FILE ]]; then
     AWS_ROLE_SESSION_NAME="nginx-s3-gateway"
   fi
 
+# d) Using EKS pod identity. This is indicated by AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE being set.
+#    See https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html.
+#    Example: We are running inside an EKS cluster with a pod identity configured.
+elif [[ -v AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE ]]; then
+  echo "Running inside EKS with EKS pod identity"
+  if [[ ! -v AWS_ROLE_SESSION_NAME ]]; then
+    # The default value is set as a nginx-s3-gateway unless the value is defined.
+    AWS_ROLE_SESSION_NAME="nginx-s3-gateway"
+  fi
+
 elif [[ -v S3_ACCESS_KEY_ID ]]; then
   echo "Deprecated the S3_ACCESS_KEY_ID! Use the environment variable of AWS_ACCESS_KEY_ID instead"
   failed=1


### PR DESCRIPTION
### Proposed changes

Fixes #373 

This adds an additional branch to the entrypoint which checks for `AWS_CONTAINER_AUTHORIZATION_FILE` (in the same position as this check occurs in `awscredentials.js`) to prevent the script from failing when using EKS Pod Identities.

### Checklist

Before creating a pull request (PR), run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [ ] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/.github/blob/main/CLA/cla-markdown.md).
- [x] The PR title follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation (e.g. [`README.md`](/README.md)).
