### PR TITLE
fix: fixes `env` compatibility problem with container execution

### DIFF
--- a/common/docker-entrypoint.d/00-check-for-required-env.sh
+++ b/common/docker-entrypoint.d/00-check-for-required-env.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/bash
 #
 #  Copyright 2020 F5 Networks
 #
@@ -44,7 +44,7 @@ elif [[ -v AWS_SESSION_TOKEN ]]; then
 # b) Using Instance Metadata Service (IMDS) credentials, if IMDS is present at http://169.254.169.254.
 #    See https://docs.aws.amazon.com/sdkref/latest/guide/feature-imds-credentials.html.
 #    Example: We are running inside an EC2 instance.
-elif TOKEN=`curl -X PUT --silent --fail --connect-timeout 2 --max-time 2 "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"` && curl  -H "X-aws-ec2-metadata-token: $TOKEN" --output /dev/null --silent --head --fail --connect-timeout 2 --max-time 5 "http://169.254.169.254"; then 
+elif TOKEN=`curl -X PUT --silent --fail --connect-timeout 2 --max-time 2 "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600"` && curl  -H "X-aws-ec2-metadata-token: $TOKEN" --output /dev/null --silent --head --fail --connect-timeout 2 --max-time 5 "http://169.254.169.254"; then
   echo "Running inside an EC2 instance, using IMDS for credentials"
 
 # c) Using assume role credentials. This is indicated by AWS_WEB_IDENTITY_TOKEN_FILE being set.

--- a/common/docker-entrypoint.d/22-enable_js_fetch_trusted_certificate.sh
+++ b/common/docker-entrypoint.d/22-enable_js_fetch_trusted_certificate.sh
@@ -1,3 +1,5 @@
+#!/usr/bin/bash
+
 #
 #  Copyright 2022 F5 Networks
 #

--- a/common/docker-entrypoint.sh
+++ b/common/docker-entrypoint.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/usr/bin/bash
 #
 #  Copyright 2020 F5 Networks
 #
@@ -71,7 +71,7 @@ fi
 # See documentation for this feature. We do not parse this as a boolean
 # since "true" and "false" are the required values of the header this populates
 if [ "${CORS_ALLOW_PRIVATE_NETWORK_ACCESS}" != "true" ] && [ "${CORS_ALLOW_PRIVATE_NETWORK_ACCESS}" != "false" ]; then
-  export CORS_ALLOW_PRIVATE_NETWORK_ACCESS=""  
+  export CORS_ALLOW_PRIVATE_NETWORK_ACCESS=""
 fi
 
 # This is the primary logic to determine the s3 host used for the


### PR DESCRIPTION
Fixes #127 

This change hardcodes the path to `bash` when it is used within Docker. Ideally, we should be able to use `env` to locate `bash`, it seems that some container execution platforms do not support it.

Invoking `bash` from the development, CI, or Ubuntu full installs will continue to use the `env` pattern.

This change builds off of this [PR](https://github.com/nginx/nginx-s3-gateway/pull/127).

### Proposed changes

* Updated the shebang line in `common/docker-entrypoint.d/00-check-for-required-env.sh` from `#!/usr/bin/env bash` to `#!/usr/bin/bash` for consistency and direct interpreter invocation.
* Updated the shebang line in `common/docker-entrypoint.sh` from `#!/usr/bin/env bash` to `#!/usr/bin/bash`.
* Added a shebang line (`#!/usr/bin/bash`) to `common/docker-entrypoint.d/22-enable_js_fetch_trusted_certificate.sh` to ensure the script is executed with the correct shell.the [supported keywords](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue) in this PR description (not in the title of the PR).

### Checklist

Before creating a pull request (PR), run through this checklist and mark each as complete:

- [X] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [X] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [X] The PR title follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [X] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [X] If applicable, I have checked that any relevant tests pass after adding my changes.
- [X] I have updated any relevant documentation (e.g. [`README.md`](/README.md)).
