### PR TITLE
fix: redirect with real scheme from X-Forwarded-Proto

### DIFF
--- a/common/etc/nginx/templates/default.conf.template
+++ b/common/etc/nginx/templates/default.conf.template
@@ -13,6 +13,13 @@ map $request_uri $uri_full_path {
     "~^(?P<path>.*?)(\?.*)*$"  $path;
 }
 
+# Retrieves the initial scheme send by the User Agent. This uses
+# X-Forwarded-Proto header added by possible proxy or load balancer.
+map $http_x_forwarded_proto $real_scheme {
+    default    $http_x_forwarded_proto;
+    ""         $scheme;
+}
+
 # Remove/replace a portion of request URL (if configured)
 map $uri_full_path $uri_path {
 	"~^$STRIP_LEADING_DIRECTORY_PATH(.*)"  $PREFIX_LEADING_DIRECTORY_PATH$1;
@@ -304,7 +311,7 @@ server {
         # 302 to request without slashes
         # Adding a ? to the end of the replacement param in `rewrite` prevents it from
         # appending the query string.
-        rewrite ^ $scheme://$http_host$uri/$is_args$query_string? redirect;
+        rewrite ^ $real_scheme://$http_host$uri/$is_args$query_string? redirect;
     }
 
     # Provide a hint to the client on 405 errors of the acceptable request methods


### PR DESCRIPTION
### Proposed changes

Redirections are now based on X-Forwarded-Proto when it exists.
This fixes integrations issues behind load balancers or proxy. The browser was redirected with a wrong protocol.
[Issue #433](https://github.com/nginx/nginx-s3-gateway/issues/433)

### Checklist

Before creating a pull request (PR), run through this checklist and mark each as complete:

- [x] I have read the [contributing guidelines](/CONTRIBUTING.md).
- [x] I have signed the [F5 Contributor License Agreement (CLA)](https://github.com/f5/f5-cla/blob/main/docs/f5_cla.md).
- [x] The PR title follows the [Conventional Commits specification](https://www.conventionalcommits.org/en/v1.0.0/).
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works.
- [x] If applicable, I have checked that any relevant tests pass after adding my changes.
- [x] I have updated any relevant documentation (e.g. [`README.md`](/README.md)).
